### PR TITLE
Trap errors in our Sidekiq jobs

### DIFF
--- a/app/domain/streams/message_processor_job.rb
+++ b/app/domain/streams/message_processor_job.rb
@@ -14,9 +14,20 @@ module Streams
 
       Monitor::Messages.run(routing_key)
 
-      ActiveRecord::Base.transaction do
-        message.handler.process
+      begin
+        ActiveRecord::Base.transaction do
+          message.handler.process
+        end
+      rescue StandardError => e
+        GovukError.notify(e)
+        logger.error(e.message)
       end
+    end
+
+  private
+
+    def logger
+      Logger.new(STDERR)
     end
   end
 end

--- a/spec/domain/streams/message_processor_job_spec.rb
+++ b/spec/domain/streams/message_processor_job_spec.rb
@@ -5,4 +5,25 @@ RSpec.describe Streams::MessageProcessorJob do
 
     subject.perform(message.payload, message.delivery_info.routing_key)
   end
+
+  context 'exception thrown during processing' do
+    let(:message) { build(:message, routing_key: 'news_story.minor') }
+    let(:exception) { StandardError.new('the error message') }
+    let(:logger) { double('logger', error: nil) }
+
+    before do
+      allow_any_instance_of(Streams::Handlers::SingleItemHandler).to receive(:process).and_raise(exception)
+      allow(Logger).to receive(:new).and_return(logger)
+      allow(GovukError).to receive(:notify)
+      subject.perform(message.payload, message.delivery_info.routing_key)
+    end
+
+    it 'logs the error message only' do
+      expect(logger).to have_received(:error).once.with('the error message')
+    end
+
+    it 'sends the exception to sentry' do
+      expect(GovukError).to have_received(:notify).with(exception)
+    end
+  end
 end


### PR DESCRIPTION
The default behaviour for the Sidekiq jobs is
the write the whole exception including a full stack
trace into the logs.

This is causing problems when we have an error in our code
because the huge log files fill the hard disk, causing problems
for the other apps on the `backend` machines.

This PR traps the errors in our own code and:

* Writes only the message from the exception to the logs
* Sends the entire exception to sentry, where we have set up a Slack
  notification for recurring errors.

Trello: https://trello.com/c/bxmM4ujk/1355-configure-logging-to-exclude-stack-trace-for-sidekiq-jobs#

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
