### PR TITLE
Use env vars for queue names

### DIFF
--- a/lib/tasks/publishing_api_consumer.rake
+++ b/lib/tasks/publishing_api_consumer.rake
@@ -5,7 +5,7 @@ namespace :publishing_api do
   task consumer: :environment do
     begin
       GovukMessageQueueConsumer::Consumer.new(
-        queue_name: 'content_data_api',
+        queue_name: ENV['RABBITMQ_QUEUE'],
         processor: Streams::Consumer.new,
       ).run
     rescue SignalException
@@ -17,7 +17,7 @@ namespace :publishing_api do
   task bulk_import_consumer: :environment do
     begin
       GovukMessageQueueConsumer::Consumer.new(
-        queue_name: 'content_data_api_govuk_importer',
+        queue_name: ENV['RABBITMQ_QUEUE_BULK'],
         processor: Streams::Consumer.new,
       ).run
     rescue SignalException

--- a/spec/tasks/publishing_api_spec.rb
+++ b/spec/tasks/publishing_api_spec.rb
@@ -1,6 +1,11 @@
 RSpec.describe 'rake publishing_api:*', type: task do
   let(:consumer) { double('message_consumer', run: nil) }
 
+  before(:all) do
+    ENV['RABBITMQ_QUEUE'] = 'content_data_api'
+    ENV['RABBITMQ_QUEUE_BULK'] = 'content_data_api_govuk_importer'
+  end
+
   it 'starts listener for PublishingAPI events' do
     expect(GovukMessageQueueConsumer::Consumer).to receive(:new).with(
       queue_name: 'content_data_api',


### PR DESCRIPTION
Consumers now use environment variables to retrieve the queue names. This removed hard coded values from the codebase.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
