### PR TITLE
Fix the last three months aggregations spec

### DIFF
--- a/spec/models/aggregations/search_last_three_months_spec.rb
+++ b/spec/models/aggregations/search_last_three_months_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Aggregations::SearchLastThreeMonths, type: :model do
 
     create :metric, edition: edition1, date: 1.months.ago
     create :metric, edition: edition1, date: 2.months.ago
-    create :metric, edition: edition2, date: 3.months.ago
+    create :metric, edition: edition2, date: 3.months.ago + 1.day
 
     recalculate_aggregations!
 


### PR DESCRIPTION
It was broken today and yesterday, as Ruby 3.months.ago was the 28th
of Feb, and this didn't get included in the materialised view.

At least in Content Data, the date displayed for this is from the 1st
of March, so add a day to the date for the metric, so that it lies
within the last three months.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* ~~Added/updated feature tests.~~
* ~~Added/updated relevant documentation.~~
* ~~Added to Trello card.~~
