### PR TITLE
Specify root: for the document types and organisation api endpoints

### DIFF
--- a/app/controllers/api/document_types_controller.rb
+++ b/app/controllers/api/document_types_controller.rb
@@ -1,6 +1,6 @@
 class Api::DocumentTypesController < Api::BaseController
   def index
     @document_types = Finders::AllDocumentTypes.run
-    render json: @document_types
+    render root: :document_types, json: @document_types
   end
 end

--- a/app/controllers/api/organisations_controller.rb
+++ b/app/controllers/api/organisations_controller.rb
@@ -1,6 +1,6 @@
 class Api::OrganisationsController < Api::BaseController
   def index
     @organisations = Finders::AllOrganisations.run
-    render json: @organisations
+    render root: :organisations, json: @organisations
   end
 end

--- a/spec/requests/document_types_spec.rb
+++ b/spec/requests/document_types_spec.rb
@@ -1,6 +1,9 @@
 RSpec.describe '/document_types' do
   before do
     create :user
+  end
+
+  it 'returns distinct document types ordered by title' do
     create :edition, document_type: 'guide'
     create :edition, document_type: 'manual'
     create :edition, document_type: 'manual'
@@ -10,15 +13,19 @@ RSpec.describe '/document_types' do
     create :edition, document_type: 'vanish'
     create :edition, document_type: 'unpublishing'
     create :edition, document_type: 'need'
-  end
 
-  it 'returns distinct document types ordered by title' do
     get '/api/v1/document_types'
     json = JSON.parse(response.body).deep_symbolize_keys
     expect(json).to eq(document_types: [
       { id: 'guide', name: 'Guide' },
       { id: 'manual', name: 'Manual' }
     ])
+  end
+
+  it 'works with no editions' do
+    get '/api/v1/document_types'
+    json = JSON.parse(response.body).deep_symbolize_keys
+    expect(json).to eq(document_types: [])
   end
 
   include_examples 'API response', '/api/v1/document_types'

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe '/organisations' do
   before do
     create :user
-    create :edition, document_type: 'organisation', content_id: 'org-1-id', title: 'z Org'
-    create :edition, document_type: 'organisation', content_id: 'org-2-id', title: 'a Org', acronym: 'HMRC'
   end
 
   it 'returns distinct organisations ordered by title' do
+    create :edition, document_type: 'organisation', content_id: 'org-1-id', title: 'z Org'
+    create :edition, document_type: 'organisation', content_id: 'org-2-id', title: 'a Org', acronym: 'HMRC'
+
     get '/api/v1/organisations'
     json = JSON.parse(response.body).deep_symbolize_keys
     expect(json).to eq(
@@ -14,6 +15,12 @@ RSpec.describe '/organisations' do
         { name: 'z Org', id: 'org-1-id', acronym: nil }
       ]
     )
+  end
+
+  it 'works with no editions' do
+    get '/api/v1/organisations'
+    json = JSON.parse(response.body).deep_symbolize_keys
+    expect(json).to eq(organisations: [])
   end
 
   include_examples 'API response', '/api/v1/organisations'


### PR DESCRIPTION
This avoids an error [1] when there are no document types or
organisations in the local database, which can reasonably occur when
running the application locally, before you've pulled in some data.

1: ArgumentError - Cannot infer root key from collection type. Please
specify the root or each_serializer option, or render a JSON String:

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* ~~Added/updated relevant documentation.~~
* ~~Added to Trello card.~~
