### PR TITLE
Rename `organisation_id` to `primary_organisation_id`

### DIFF
--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -1,9 +1,5 @@
 class Finders::Content
   def self.call(filter:)
-    raise ArgumentError unless filter.has_key?(:organisation_id) && filter.has_key?(:date_range)
-
-    filter.assert_valid_keys :search_term, :date_range, :organisation_id, :document_type, :page, :page_size, :sort_attribute, :sort_direction
-
     new(filter).call
   end
 
@@ -23,6 +19,14 @@ private
   NONE = 'none'.freeze
 
   def initialize(filter)
+    raise ArgumentError unless
+      filter.has_key?(:organisation_id) && filter.has_key?(:date_range)
+
+    filter.assert_valid_keys(
+      :search_term, :date_range, :organisation_id, :document_type, :page,
+      :page_size, :sort_attribute, :sort_direction
+    )
+
     @filter = filter
 
     @page = filter[:page] || 1

--- a/app/domain/finders/content.rb
+++ b/app/domain/finders/content.rb
@@ -71,12 +71,12 @@ private
   end
 
   def find_by_organisation(scope)
-    organisation_id = @filter.fetch(:organisation_id)
+    primary_organisation_id = @filter.fetch(:organisation_id)
 
-    if organisation_id == NONE
-      scope = scope.where('organisation_id IS NULL')
-    elsif organisation_id != ALL
-      scope = scope.where(organisation_id: organisation_id)
+    if primary_organisation_id == NONE
+      scope = scope.where('primary_organisation_id IS NULL')
+    elsif primary_organisation_id != ALL
+      scope = scope.where(primary_organisation_id: primary_organisation_id)
     end
     scope
   end
@@ -110,14 +110,17 @@ private
   end
 
   def aggregates
-    %w(base_path title organisation_id document_type upviews pviews useful_yes useful_no satisfaction searches feedex pdf_count words reading_time)
+    %w(base_path title primary_organisation_id document_type upviews pviews useful_yes useful_no satisfaction searches feedex pdf_count words reading_time)
   end
 
   def array_to_hash(array)
     {
       base_path: array[:base_path],
       title: array[:title],
-      organisation_id: array[:organisation_id],
+      # TODO: Remove this once the Content Data Admin is using the
+      # primary_organisation_id value.
+      organisation_id: array[:primary_organisation_id],
+      primary_organisation_id: array[:primary_organisation_id],
       document_type: array[:document_type],
       upviews: array[:upviews],
       pviews: array[:pviews],

--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -16,7 +16,7 @@ class Streams::Messages::BaseMessage
       locale: locale,
       document_text: document_text,
       first_published_at: parse_time('first_published_at'),
-      organisation_id: primary_organisation['content_id'],
+      primary_organisation_id: primary_organisation['content_id'],
       primary_organisation_title: primary_organisation['title'],
       primary_organisation_withdrawn: primary_organisation['withdrawn'],
       public_updated_at: parse_time('public_updated_at'),

--- a/app/views/content/show.json.jbuilder
+++ b/app/views/content/show.json.jbuilder
@@ -1,7 +1,10 @@
 json.results @content_items do |content_item|
   json.base_path content_item[:base_path]
   json.title content_item[:title]
-  json.organisation_id content_item[:organisation_id]
+  # TODO: Remove this once the Content Data Admin is using the
+  # primary_organisation_id value
+  json.organisation_id content_item[:primary_organisation_id]
+  json.primary_organisation_id content_item[:primary_organisation_id]
   json.document_type content_item[:document_type]
   json.pviews content_item[:pviews]
   json.upviews content_item[:upviews]

--- a/db/migrate/20190603080748_rename_dimensions_edition_organisation_id.rb
+++ b/db/migrate/20190603080748_rename_dimensions_edition_organisation_id.rb
@@ -1,0 +1,9 @@
+class RenameDimensionsEditionOrganisationId < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :dimensions_editions, :organisation_id, :primary_organisation_id
+  end
+
+  def down
+    rename_column :dimensions_editions, :primary_organisation_id, :organisation_id
+  end
+end

--- a/db/migrate/20190603083348_update_aggregations_search_last_months_to_version_7.rb
+++ b/db/migrate/20190603083348_update_aggregations_search_last_months_to_version_7.rb
@@ -1,0 +1,10 @@
+class UpdateAggregationsSearchLastMonthsToVersion7 < ActiveRecord::Migration[5.2]
+  def change
+    update_view(
+      :aggregations_search_last_months,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+    )
+  end
+end

--- a/db/migrate/20190603083456_update_aggregations_search_last_thirty_days_to_version_9.rb
+++ b/db/migrate/20190603083456_update_aggregations_search_last_thirty_days_to_version_9.rb
@@ -1,0 +1,10 @@
+class UpdateAggregationsSearchLastThirtyDaysToVersion9 < ActiveRecord::Migration[5.2]
+  def change
+    update_view(
+      :aggregations_search_last_thirty_days,
+      version: 9,
+      revert_to_version: 8,
+      materialized: true
+    )
+  end
+end

--- a/db/migrate/20190603083504_update_aggregations_search_last_three_months_to_version_9.rb
+++ b/db/migrate/20190603083504_update_aggregations_search_last_three_months_to_version_9.rb
@@ -1,0 +1,10 @@
+class UpdateAggregationsSearchLastThreeMonthsToVersion9 < ActiveRecord::Migration[5.2]
+  def change
+    update_view(
+      :aggregations_search_last_three_months,
+      version: 9,
+      revert_to_version: 8,
+      materialized: true
+    )
+  end
+end

--- a/db/migrate/20190603083515_update_aggregations_search_last_twelve_months_to_version_9.rb
+++ b/db/migrate/20190603083515_update_aggregations_search_last_twelve_months_to_version_9.rb
@@ -1,0 +1,10 @@
+class UpdateAggregationsSearchLastTwelveMonthsToVersion9 < ActiveRecord::Migration[5.2]
+  def change
+    update_view(
+      :aggregations_search_last_twelve_months,
+      version: 9,
+      revert_to_version: 8,
+      materialized: true
+    )
+  end
+end

--- a/db/migrate/20190603083643_update_aggregations_search_last_six_months_to_version_9.rb
+++ b/db/migrate/20190603083643_update_aggregations_search_last_six_months_to_version_9.rb
@@ -1,0 +1,10 @@
+class UpdateAggregationsSearchLastSixMonthsToVersion9 < ActiveRecord::Migration[5.2]
+  def change
+    update_view(
+      :aggregations_search_last_six_months,
+      version: 9,
+      revert_to_version: 8,
+      materialized: true
+    )
+  end
+end

--- a/db/migrate/20190603111746_restore_organisation_related_view_indexes.rb
+++ b/db/migrate/20190603111746_restore_organisation_related_view_indexes.rb
@@ -1,0 +1,30 @@
+class RestoreOrganisationRelatedViewIndexes < ActiveRecord::Migration[5.2]
+  PERIODS = %w[
+    last_thirty_days
+    last_months
+    last_three_months
+    last_six_months
+    last_twelve_months
+  ].freeze
+
+  def up
+    fields = %i[primary_organisation_id upviews warehouse_item_id]
+
+    PERIODS.each do |period|
+      add_index(
+        "aggregations_search_#{period}".to_sym,
+        fields,
+        name: "search_#{period}_organisation_id".to_sym
+      )
+    end
+  end
+
+  def down
+    PERIODS.each do |period|
+      remove_index(
+        "aggregations_search_#{period}".to_sym,
+        name: "search_#{period}_organisation_id".to_sym
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_083643) do
+ActiveRecord::Schema.define(version: 2019_06_03_111746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -250,6 +250,7 @@ ActiveRecord::Schema.define(version: 2019_06_03_083643) do
   add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_month_gin_title", using: :gin
   add_index "aggregations_search_last_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_month_gin_base_path", using: :gin
   add_index "aggregations_search_last_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_month_document_type"
+  add_index "aggregations_search_last_months", ["primary_organisation_id", "upviews", "warehouse_item_id"], name: "search_last_months_organisation_id"
   add_index "aggregations_search_last_months", ["upviews", "warehouse_item_id"], name: "search_last_month_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_months", ["warehouse_item_id"], name: "aggregations_search_last_months_pk", unique: true
 
@@ -294,6 +295,7 @@ ActiveRecord::Schema.define(version: 2019_06_03_083643) do
   add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_thirty_days_gin_title", using: :gin
   add_index "aggregations_search_last_thirty_days", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_thirty_days_gin_base_path", using: :gin
   add_index "aggregations_search_last_thirty_days", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_document_type"
+  add_index "aggregations_search_last_thirty_days", ["primary_organisation_id", "upviews", "warehouse_item_id"], name: "search_last_thirty_days_organisation_id"
   add_index "aggregations_search_last_thirty_days", ["upviews", "warehouse_item_id"], name: "search_last_thirty_days_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_thirty_days", ["warehouse_item_id"], name: "aggregations_search_last_thirty_days_pk", unique: true
 
@@ -361,6 +363,7 @@ ActiveRecord::Schema.define(version: 2019_06_03_083643) do
   add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_three_months_gin_title", using: :gin
   add_index "aggregations_search_last_three_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_three_months_gin_base_path", using: :gin
   add_index "aggregations_search_last_three_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_three_months_document_type"
+  add_index "aggregations_search_last_three_months", ["primary_organisation_id", "upviews", "warehouse_item_id"], name: "search_last_three_months_organisation_id"
   add_index "aggregations_search_last_three_months", ["upviews", "warehouse_item_id"], name: "search_last_three_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_three_months", ["warehouse_item_id"], name: "aggregations_search_last_three_months_pk", unique: true
 
@@ -428,6 +431,7 @@ ActiveRecord::Schema.define(version: 2019_06_03_083643) do
   add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_twelve_months_gin_title", using: :gin
   add_index "aggregations_search_last_twelve_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_twelve_months_gin_base_path", using: :gin
   add_index "aggregations_search_last_twelve_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_document_type"
+  add_index "aggregations_search_last_twelve_months", ["primary_organisation_id", "upviews", "warehouse_item_id"], name: "search_last_twelve_months_organisation_id"
   add_index "aggregations_search_last_twelve_months", ["upviews", "warehouse_item_id"], name: "search_last_twelve_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_twelve_months", ["warehouse_item_id"], name: "aggregations_search_last_twelve_months_pk", unique: true
 
@@ -495,6 +499,7 @@ ActiveRecord::Schema.define(version: 2019_06_03_083643) do
   add_index "aggregations_search_last_six_months", "to_tsvector('english'::regconfig, (title)::text)", name: "aggregations_search_last_six_months_gin_title", using: :gin
   add_index "aggregations_search_last_six_months", "to_tsvector('english'::regconfig, replace((base_path)::text, '/'::text, ' '::text))", name: "aggregations_search_last_six_months_gin_base_path", using: :gin
   add_index "aggregations_search_last_six_months", ["document_type", "upviews", "warehouse_item_id"], name: "search_last_six_months_document_type"
+  add_index "aggregations_search_last_six_months", ["primary_organisation_id", "upviews", "warehouse_item_id"], name: "search_last_six_months_organisation_id"
   add_index "aggregations_search_last_six_months", ["upviews", "warehouse_item_id"], name: "search_last_six_months_upviews", order: { upviews: "DESC NULLS LAST", warehouse_item_id: :desc }
   add_index "aggregations_search_last_six_months", ["warehouse_item_id"], name: "aggregations_search_last_six_months_pk", unique: true
 

--- a/db/views/aggregations_search_last_months_v07.sql
+++ b/db/views/aggregations_search_last_months_v07.sql
@@ -1,0 +1,39 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.primary_organisation_id as primary_organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CURRENT_DATE as updated_at,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(aggregations_monthly_metrics.upviews) AS upviews,
+      sum(aggregations_monthly_metrics.pviews) AS pviews,
+      sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+      sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+      sum(aggregations_monthly_metrics.feedex) AS feedex,
+      sum(aggregations_monthly_metrics.searches) AS searches
+    FROM aggregations_monthly_metrics
+    INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+    INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+    WHERE dimensions_months.id = to_char(NOW() - interval '1 month','YYYY-MM')
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_six_months_v09.sql
+++ b/db/views/aggregations_search_last_six_months_v09.sql
@@ -1,0 +1,67 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.primary_organisation_id as primary_organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CURRENT_DATE as updated_at,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.pviews) AS pviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.feedex) AS feedex,
+      sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '5 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '6 month')
+             AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '5 month'),'YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_thirty_days_v09.sql
+++ b/db/views/aggregations_search_last_thirty_days_v09.sql
@@ -1,0 +1,41 @@
+SELECT
+  dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.primary_organisation_id as primary_organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CURRENT_DATE as updated_at,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+    SELECT warehouse_item_id,
+      max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+      sum(facts_metrics.upviews) AS upviews,
+      sum(facts_metrics.pviews) AS pviews,
+      sum(facts_metrics.useful_yes) AS useful_yes,
+      sum(facts_metrics.useful_no) AS useful_no,
+      sum(facts_metrics.feedex) AS feedex,
+      sum(facts_metrics.searches) AS searches
+     FROM facts_metrics
+       JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+       JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+     WHERE (facts_metrics.dimensions_date_id > (('yesterday'::text)::date - '30 days'::interval day))
+       AND (facts_metrics.dimensions_date_id < ('now'::text)::date)
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_three_months_v09.sql
+++ b/db/views/aggregations_search_last_three_months_v09.sql
@@ -1,0 +1,67 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.primary_organisation_id as primary_organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CURRENT_DATE as updated_at,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+      SELECT  warehouse_item_id,
+      max(agg.dimensions_edition_id) AS dimensions_edition_id,
+      sum(agg.upviews) AS upviews,
+      sum(agg.pviews) AS pviews,
+      sum(agg.useful_yes) AS useful_yes,
+      sum(agg.useful_no) AS useful_no,
+      sum(agg.feedex) AS feedex,
+      sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '3 month')
+             AND facts_metrics.dimensions_date_id < to_char(('yesterday'::text)::date - interval '2 month','YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')

--- a/db/views/aggregations_search_last_twelve_months_v09.sql
+++ b/db/views/aggregations_search_last_twelve_months_v09.sql
@@ -1,0 +1,68 @@
+select dimensions_editions.warehouse_item_id as warehouse_item_id,
+  dimensions_editions.title as title,
+  dimensions_editions.document_type as document_type,
+  dimensions_editions.base_path as base_path,
+  dimensions_editions.primary_organisation_id as primary_organisation_id,
+  dimensions_editions.id as dimensions_edition_id,
+  aggregations.upviews::bigint as upviews,
+  aggregations.pviews::bigint as pviews,
+  aggregations.feedex::bigint as feedex,
+  aggregations.useful_yes::bigint as useful_yes,
+  aggregations.useful_no::bigint as useful_no,
+  CURRENT_DATE as updated_at,
+  CASE
+    WHEN useful_yes + useful_no = 0 THEN NULL
+    ELSE useful_yes::float / (useful_yes + useful_no)
+  END as satisfaction,
+  aggregations.searches::bigint as searches,
+  facts_editions.words as words,
+  facts_editions.pdf_count as pdf_count,
+  facts_editions.reading_time as reading_time
+FROM
+  (
+    SELECT  warehouse_item_id,
+    max(agg.dimensions_edition_id) AS dimensions_edition_id,
+    sum(agg.upviews) AS upviews,
+    sum(agg.pviews) AS pviews,
+    sum(agg.useful_yes) AS useful_yes,
+    sum(agg.useful_no) AS useful_no,
+    sum(agg.feedex) AS feedex,
+    sum(agg.searches) AS searches
+    FROM(
+        -- Use monthly aggregations
+        SELECT  warehouse_item_id,
+          max(aggregations_monthly_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(aggregations_monthly_metrics.upviews) AS upviews,
+          sum(aggregations_monthly_metrics.pviews) AS pviews,
+          sum(aggregations_monthly_metrics.useful_yes) AS useful_yes,
+          sum(aggregations_monthly_metrics.useful_no) AS useful_no,
+          sum(aggregations_monthly_metrics.feedex) AS feedex,
+          sum(aggregations_monthly_metrics.searches) AS searches
+        FROM aggregations_monthly_metrics
+        INNER JOIN dimensions_months ON dimensions_months.id = aggregations_monthly_metrics.dimensions_month_id
+        INNER JOIN dimensions_editions ON dimensions_editions.id = aggregations_monthly_metrics.dimensions_edition_id
+        WHERE dimensions_months.id >= to_char(('yesterday'::text)::date - interval '11 month','YYYY-MM')
+        GROUP BY warehouse_item_id
+      UNION
+        -- Use daily metrics
+        SELECT warehouse_item_id,
+          max(facts_metrics.dimensions_edition_id) AS dimensions_edition_id,
+          sum(facts_metrics.upviews) AS upviews,
+          sum(facts_metrics.pviews) AS pviews,
+          sum(facts_metrics.useful_yes) AS useful_yes,
+          sum(facts_metrics.useful_no) AS useful_no,
+          sum(facts_metrics.feedex) AS feedex,
+          sum(facts_metrics.searches) AS searches
+         FROM facts_metrics
+           JOIN dimensions_dates ON dimensions_dates.date = facts_metrics.dimensions_date_id
+           JOIN dimensions_editions ON dimensions_editions.id = facts_metrics.dimensions_edition_id
+        WHERE facts_metrics.dimensions_date_id > (('yesterday'::text)::date - interval '12 month')
+             AND facts_metrics.dimensions_date_id < to_char((('yesterday'::text)::date - interval '11 month'),'YYYY-MM-01')::date
+        GROUP BY warehouse_item_id
+    ) as agg
+    GROUP BY warehouse_item_id
+  ) as aggregations
+INNER JOIN dimensions_editions ON aggregations.dimensions_edition_id = dimensions_editions.id
+INNER JOIN facts_editions ON dimensions_editions.id = facts_editions.dimensions_edition_id
+WHERE dimensions_editions.document_type NOT IN ('gone','vanish','need','unpublishing','redirect')
+

--- a/spec/domain/finders/content_spec.rb
+++ b/spec/domain/finders/content_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Finders::Content do
   end
 
   it 'returns the aggregations for the past 30 days' do
-    edition1 = create :edition, base_path: '/path1', date: 2.months.ago, organisation_id: primary_org_id
-    edition2 = create :edition, base_path: '/path2', date: 2.months.ago, organisation_id: primary_org_id
+    edition1 = create :edition, base_path: '/path1', date: 2.months.ago, primary_organisation_id: primary_org_id
+    edition2 = create :edition, base_path: '/path2', date: 2.months.ago, primary_organisation_id: primary_org_id
 
     create :metric, edition: edition1, date: 15.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
     create :metric, edition: edition1, date: 10.days.ago, upviews: 20, useful_yes: 5, useful_no: 1, searches: 1
@@ -38,13 +38,13 @@ RSpec.describe Finders::Content do
   it 'returns the metadata for the past 30 days' do
     edition1 = create :edition,
                       base_path: '/path1',
-                      organisation_id: primary_org_id,
+                      primary_organisation_id: primary_org_id,
                       title: 'title-01',
                       document_type: 'document-type-01'
 
     edition2 = create :edition,
                       base_path: '/path2',
-                      organisation_id: primary_org_id,
+                      primary_organisation_id: primary_org_id,
                       title: 'title-02',
                       document_type: 'document-type-02'
 
@@ -62,8 +62,8 @@ RSpec.describe Finders::Content do
 
   context 'Newly created editions before ETL process' do
     it 'returns total_results for editions with facts metrics' do
-      edition1 = create :edition, base_path: '/path1', date: 10.days.ago, organisation_id: primary_org_id
-      create :edition, base_path: '/path2', date: 10.days.ago, organisation_id: primary_org_id
+      edition1 = create :edition, base_path: '/path1', date: 10.days.ago, primary_organisation_id: primary_org_id
+      create :edition, base_path: '/path2', date: 10.days.ago, primary_organisation_id: primary_org_id
 
       create :metric, edition: edition1, date: 10.days.ago, upviews: 15, useful_yes: 8, useful_no: 9, searches: 10
 
@@ -77,8 +77,8 @@ RSpec.describe Finders::Content do
 
   describe 'Other date ranges' do
     let(:this_month_date) { Date.today }
-    let(:edition1) { create :edition, base_path: '/path1', date: 2.months.ago, organisation_id: primary_org_id }
-    let(:edition2) { create :edition, base_path: '/path2', date: 2.months.ago, organisation_id: primary_org_id }
+    let(:edition1) { create :edition, base_path: '/path1', date: 2.months.ago, primary_organisation_id: primary_org_id }
+    let(:edition2) { create :edition, base_path: '/path2', date: 2.months.ago, primary_organisation_id: primary_org_id }
 
     it 'returns aggregations for last month' do
       last_month_date = (Date.today - 1.month)
@@ -161,7 +161,7 @@ RSpec.describe Finders::Content do
 
   describe 'Filter by all organisations' do
     let(:edition1) { create :edition, date: 15.days.ago }
-    let(:edition2) { create :edition, date: 15.days.ago, organisation_id: nil }
+    let(:edition2) { create :edition, date: 15.days.ago, primary_organisation_id: nil }
 
     before do
       create :metric, edition: edition1, upviews: 20, date: 15.days.ago
@@ -179,11 +179,11 @@ RSpec.describe Finders::Content do
   end
 
   describe 'Filter by null organisations' do
-    let(:edition1) { create :edition, date: 15.days.ago, organisation_id: nil }
+    let(:edition1) { create :edition, date: 15.days.ago, primary_organisation_id: nil }
 
     before do
       create :metric, edition: edition1, date: 15.days.ago
-      edition2 = create :edition, date: 15.days.ago, organisation_id: primary_org_id
+      edition2 = create :edition, date: 15.days.ago, primary_organisation_id: primary_org_id
       create :metric, edition: edition2, date: 15.days.ago
       recalculate_aggregations!
     end
@@ -201,7 +201,7 @@ RSpec.describe Finders::Content do
       4.times do |n|
         edition = create :edition,
                          base_path: "/path/#{n}",
-                         organisation_id: primary_org_id,
+                         primary_organisation_id: primary_org_id,
                          warehouse_item_id: "item-#{n}"
         create :metric, edition: edition, date: 15.days.ago, upviews: (100 - n)
       end
@@ -209,7 +209,7 @@ RSpec.describe Finders::Content do
       # not live edition - should not affect total results
       old_edition = create :edition,
                            base_path: '/path/0',
-                           organisation_id: primary_org_id,
+                           primary_organisation_id: primary_org_id,
                            live: false,
                            warehouse_item_id: 'item-0'
       create :metric, edition: old_edition, date: 15.days.ago
@@ -247,9 +247,9 @@ RSpec.describe Finders::Content do
   describe 'Order' do
     context 'when there are NULLS' do
       before do
-        edition1 = create :edition, title: 'first', organisation_id: primary_org_id
-        edition2 = create :edition, title: 'second', organisation_id: primary_org_id
-        edition3 = create :edition, title: 'null', organisation_id: primary_org_id
+        edition1 = create :edition, title: 'first', primary_organisation_id: primary_org_id
+        edition2 = create :edition, title: 'second', primary_organisation_id: primary_org_id
+        edition3 = create :edition, title: 'null', primary_organisation_id: primary_org_id
 
         create :metric, edition: edition1, date: 15.days.ago, useful_yes: 1, useful_no: 0 # satisfaction = 1.0
         create :metric, edition: edition2, date: 15.days.ago, useful_yes: 0, useful_no: 1 # satisfaction = 0.0
@@ -274,9 +274,9 @@ RSpec.describe Finders::Content do
 
     context 'when values do not repeat' do
       before do
-        edition1 = create :edition, title: 'last', organisation_id: primary_org_id
-        edition2 = create :edition, title: 'middle', organisation_id: primary_org_id
-        edition3 = create :edition, title: 'first', organisation_id: primary_org_id
+        edition1 = create :edition, title: 'last', primary_organisation_id: primary_org_id
+        edition2 = create :edition, title: 'middle', primary_organisation_id: primary_org_id
+        edition3 = create :edition, title: 'first', primary_organisation_id: primary_org_id
 
         create :metric, edition: edition1, date: 15.days.ago, upviews: 1, feedex: 3
         create :metric, edition: edition2, date: 15.days.ago, upviews: 2, feedex: 2
@@ -308,8 +308,8 @@ RSpec.describe Finders::Content do
 
     context 'when values repeat' do
       before do
-        edition1 = create :edition, title: 'first', warehouse_item_id: 'w1', organisation_id: primary_org_id
-        edition2 = create :edition, title: 'second', warehouse_item_id: 'w2', organisation_id: primary_org_id
+        edition1 = create :edition, title: 'first', warehouse_item_id: 'w1', primary_organisation_id: primary_org_id
+        edition2 = create :edition, title: 'second', warehouse_item_id: 'w2', primary_organisation_id: primary_org_id
 
         create :metric, edition: edition1, date: 15.days.ago, upviews: 1
         create :metric, edition: edition2, date: 15.days.ago, upviews: 1
@@ -334,7 +334,7 @@ RSpec.describe Finders::Content do
 
   describe 'when no useful_yes/no.. responses' do
     before do
-      edition = create :edition, organisation_id: primary_org_id
+      edition = create :edition, primary_organisation_id: primary_org_id
       create :metric, edition: edition, date: 15.days.ago, useful_yes: 0, useful_no: 0
 
       recalculate_aggregations!
@@ -377,8 +377,8 @@ RSpec.describe Finders::Content do
 
   describe 'Filter by title / url' do
     it 'returns the editions matching a title' do
-      edition1 = create :edition, title: 'this is a big title', date: 2.months.ago, organisation_id: primary_org_id
-      edition2 = create :edition, title: 'this is a small title', date: 2.months.ago, organisation_id: primary_org_id
+      edition1 = create :edition, title: 'this is a big title', date: 2.months.ago, primary_organisation_id: primary_org_id
+      edition2 = create :edition, title: 'this is a small title', date: 2.months.ago, primary_organisation_id: primary_org_id
 
       create :metric, edition: edition1, date: 15.days.ago
       create :metric, edition: edition2, date: 14.days.ago
@@ -391,8 +391,8 @@ RSpec.describe Finders::Content do
     end
 
     it 'returns the editions matching a base_path' do
-      edition1 = create :edition, base_path: '/this/is/a/big/base-path', date: 2.months.ago, organisation_id: primary_org_id
-      edition2 = create :edition, base_path: '/this/is/a/small/base-path', date: 2.months.ago, organisation_id: primary_org_id
+      edition1 = create :edition, base_path: '/this/is/a/big/base-path', date: 2.months.ago, primary_organisation_id: primary_org_id
+      edition2 = create :edition, base_path: '/this/is/a/small/base-path', date: 2.months.ago, primary_organisation_id: primary_org_id
 
       create :metric, edition: edition1, date: 15.days.ago
       create :metric, edition: edition2, date: 14.days.ago
@@ -406,7 +406,7 @@ RSpec.describe Finders::Content do
 
     describe 'search by base_path with full URLs' do
       before do
-        edition1 = create :edition, base_path: '/base-path', date: 2.months.ago, organisation_id: primary_org_id
+        edition1 = create :edition, base_path: '/base-path', date: 2.months.ago, primary_organisation_id: primary_org_id
 
         create :metric, edition: edition1, date: 15.days.ago
         recalculate_aggregations!

--- a/spec/domain/healthchecks/search_aggregations_spec.rb
+++ b/spec/domain/healthchecks/search_aggregations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Healthchecks::SearchAggregations do
 
   describe 'status' do
     let!(:primary_org_id) { '96cad973-92dc-41ea-a0ff-c377908fee74' }
-    let!(:edition) { create :edition, organisation_id: primary_org_id }
+    let!(:edition) { create :edition, primary_organisation_id: primary_org_id }
 
     context 'When there are search views for the last thirty days' do
       before do

--- a/spec/domain/streams/grow_dimension_spec.rb
+++ b/spec/domain/streams/grow_dimension_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Streams::GrowDimension do
           base_path
           document_text
           document_type
-          organisation_id
+          primary_organisation_id
           primary_organisation_title
           primary_organisation_withdrawn
           schema_name

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     schema_name { 'detailed_guide' }
     document_type { 'detailed_guide' }
     warehouse_item_id { "#{content_id}:#{locale}" }
-    organisation_id { '17d84dc6-e5b5-4065-a8b5-8783bd934938' }
+    primary_organisation_id { '17d84dc6-e5b5-4065-a8b5-8783bd934938' }
     withdrawn { false }
     historical { false }
     association :publishing_api_event

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -3,11 +3,11 @@ RSpec.describe '/content' do
 
   before { create :user }
 
-  let(:organisation_id) { 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
+  let(:primary_organisation_id) { 'e12e3c54-b544-4d94-ba1f-9846144374d2' }
 
   describe 'content item attributes' do
     it 'contains the expected metrics' do
-      edition1 = create :edition, date: 1.month.ago, organisation_id: organisation_id, base_path: '/path-01', facts: { pdf_count: 10, words: 300, reading_time: 2 }
+      edition1 = create :edition, date: 1.month.ago, primary_organisation_id: primary_organisation_id, base_path: '/path-01', facts: { pdf_count: 10, words: 300, reading_time: 2 }
       create :metric, date: 1.day.ago, edition: edition1, pviews: 1, upviews: 1, feedex: 1, useful_no: 1, useful_yes: 1, searches: 1
       recalculate_aggregations!
 
@@ -30,7 +30,7 @@ RSpec.describe '/content' do
     end
 
     it 'contains the expected metadata' do
-      edition1 = create :edition, date: 1.month.ago, title: 'title', organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2', document_type: 'guide', base_path: '/path-01'
+      edition1 = create :edition, date: 1.month.ago, title: 'title', primary_organisation_id: 'e12e3c54-b544-4d94-ba1f-9846144374d2', document_type: 'guide', base_path: '/path-01'
       create :metric, date: 1.day.ago, edition: edition1
       recalculate_aggregations!
 
@@ -48,8 +48,8 @@ RSpec.describe '/content' do
   end
 
   describe 'time periods' do
-    let(:edition1) { create :edition, date: 1.month.ago, organisation_id: organisation_id, base_path: '/path-01' }
-    let(:edition2) { create :edition, date: 3.months.ago, organisation_id: organisation_id, base_path: '/path-02' }
+    let(:edition1) { create :edition, date: 1.month.ago, primary_organisation_id: primary_organisation_id, base_path: '/path-01' }
+    let(:edition2) { create :edition, date: 3.months.ago, primary_organisation_id: primary_organisation_id, base_path: '/path-02' }
     let(:beginning_of_this_month) { Date.yesterday.beginning_of_month }
     let(:beginning_of_last_month) { Date.yesterday.beginning_of_month - 1.month }
 
@@ -167,16 +167,16 @@ RSpec.describe '/content' do
 
   describe 'Filter by document type' do
     before do
-      edition1 = create :edition, date: 1.month.ago, document_type: 'a-document-type', organisation_id: organisation_id
+      edition1 = create :edition, date: 1.month.ago, document_type: 'a-document-type', primary_organisation_id: primary_organisation_id
       create :metric, date: 15.days.ago, edition: edition1, upviews: 100, useful_yes: 50, useful_no: 20, searches: 20
 
-      edition2 = create :edition, date: 1.month.ago, organisation_id: organisation_id
+      edition2 = create :edition, date: 1.month.ago, primary_organisation_id: primary_organisation_id
       create :metric, date: 10.days.ago, edition: edition2, upviews: 10, useful_yes: 10, useful_no: 10, searches: 10
 
       recalculate_aggregations!
     end
 
-    subject { get '/content', params: { date_range: 'past-30-days', document_type: 'a-document-type', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'past-30-days', document_type: 'a-document-type', organisation_id: primary_organisation_id } }
 
     it 'returns 200 status' do
       subject
@@ -194,8 +194,8 @@ RSpec.describe '/content' do
 
   describe 'Filter by title' do
     before do
-      edition1 = create :edition, date: 1.month.ago, organisation_id: organisation_id, title: 'title1'
-      edition2 = create :edition, date: 1.month.ago, organisation_id: organisation_id, title: 'title2'
+      edition1 = create :edition, date: 1.month.ago, primary_organisation_id: primary_organisation_id, title: 'title1'
+      edition2 = create :edition, date: 1.month.ago, primary_organisation_id: primary_organisation_id, title: 'title2'
 
       create :metric, date: 15.days.ago, edition: edition1
       create :metric, date: 10.days.ago, edition: edition2
@@ -203,7 +203,7 @@ RSpec.describe '/content' do
       recalculate_aggregations!
     end
 
-    subject { get '/content', params: { date_range: 'past-30-days', search_term: 'title1', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'past-30-days', search_term: 'title1', organisation_id: primary_organisation_id } }
 
     it 'returns 200 status' do
       subject
@@ -221,8 +221,8 @@ RSpec.describe '/content' do
 
   describe 'Filter by base_path' do
     before do
-      edition1 = create :edition, date: 1.month.ago, organisation_id: organisation_id, base_path: 'base_path1'
-      edition2 = create :edition, date: 1.month.ago, organisation_id: organisation_id, base_path: 'base_path2'
+      edition1 = create :edition, date: 1.month.ago, primary_organisation_id: primary_organisation_id, base_path: 'base_path1'
+      edition2 = create :edition, date: 1.month.ago, primary_organisation_id: primary_organisation_id, base_path: 'base_path2'
 
       create :metric, date: 15.days.ago, edition: edition1
       create :metric, date: 10.days.ago, edition: edition2
@@ -230,7 +230,7 @@ RSpec.describe '/content' do
       recalculate_aggregations!
     end
 
-    subject { get '/content', params: { date_range: 'past-30-days', search_term: 'base_path1', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'past-30-days', search_term: 'base_path1', organisation_id: primary_organisation_id } }
 
     it 'returns 200 status' do
       subject
@@ -248,8 +248,8 @@ RSpec.describe '/content' do
 
   describe 'Filter by all organisations' do
     let(:another_org_id) { 'c97bbc95-967a-4678-848b-6f393171f194' }
-    let(:edition1) { create :edition, organisation_id: organisation_id, date: 15.days.ago }
-    let(:edition2) { create :edition, organisation_id: another_org_id, date: 15.days.ago }
+    let(:edition1) { create :edition, primary_organisation_id: primary_organisation_id, date: 15.days.ago }
+    let(:edition2) { create :edition, primary_organisation_id: another_org_id, date: 15.days.ago }
 
     subject { get '/content', params: { date_range: 'past-30-days', organisation_id: 'all' } }
 
@@ -269,13 +269,13 @@ RSpec.describe '/content' do
   end
 
   describe 'Filter by no organisation' do
-    let(:edition1) { create :edition, organisation_id: nil, date: 15.days.ago }
+    let(:edition1) { create :edition, primary_organisation_id: nil, date: 15.days.ago }
 
     subject { get '/content', params: { date_range: 'past-30-days', organisation_id: 'none' } }
 
     before do
       create :metric, edition: edition1, date: 15.days.ago
-      edition2 = create :edition, organisation_id: organisation_id, date: 15.days.ago
+      edition2 = create :edition, primary_organisation_id: primary_organisation_id, date: 15.days.ago
       create :metric, edition: edition2, date: 15.days.ago
       recalculate_aggregations!
     end
@@ -330,7 +330,7 @@ RSpec.describe '/content' do
   end
 
   describe 'Relevant content' do
-    subject { get '/content', params: { date_range: 'past-30-days', organisation_id: organisation_id } }
+    subject { get '/content', params: { date_range: 'past-30-days', organisation_id: primary_organisation_id } }
 
     before do
       create_edition_and_metric('redirect')
@@ -355,24 +355,24 @@ RSpec.describe '/content' do
     edition = create :edition,
                      document_type: document_type,
                      date: 15.days.ago,
-                     organisation_id: organisation_id
+                     primary_organisation_id: primary_organisation_id
     create :metric, edition: edition, date: 15.days.ago
     edition
   end
 
   describe 'Pagination' do
     before do
-      edition1 = create :edition, organisation_id: organisation_id, document_type: 'a-document-type', base_path: '/path-01'
+      edition1 = create :edition, primary_organisation_id: primary_organisation_id, document_type: 'a-document-type', base_path: '/path-01'
       create :metric, date: 15.days.ago, edition: edition1, upviews: 100, useful_yes: 50, useful_no: 20, searches: 20
 
-      edition2 = create :edition, organisation_id: organisation_id, base_path: '/path-02'
+      edition2 = create :edition, primary_organisation_id: primary_organisation_id, base_path: '/path-02'
       create :metric, date: 10.days.ago, edition: edition2, upviews: 10, useful_yes: 10, useful_no: 10, searches: 10
 
       recalculate_aggregations!
     end
 
     it 'returns the first page of the data' do
-      get '/content', params: { date_range: 'past-30-days', organisation_id: organisation_id, page: 1, page_size: 1 }
+      get '/content', params: { date_range: 'past-30-days', organisation_id: primary_organisation_id, page: 1, page_size: 1 }
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json[:results]).to contain_exactly(a_hash_including(base_path: '/path-01'))
@@ -380,7 +380,7 @@ RSpec.describe '/content' do
     end
 
     it 'returns the second page of the data' do
-      get '/content', params: { date_range: 'past-30-days', organisation_id: organisation_id, page: 2, page_size: 1 }
+      get '/content', params: { date_range: 'past-30-days', organisation_id: primary_organisation_id, page: 2, page_size: 1 }
 
       json = JSON.parse(response.body).deep_symbolize_keys
       expect(json[:results]).to contain_exactly(a_hash_including(base_path: '/path-02'))
@@ -407,7 +407,7 @@ RSpec.describe '/content' do
       expect(json).to eq(expected_error_response)
     end
 
-    it 'returns an error for invalid organisation_id' do
+    it 'returns an error for invalid primary_organisation_id' do
       get '/content/', params: { date_range: 'past-30-days', organisation_id: 'blah' }
 
       expect(response.status).to eq(400)

--- a/spec/support/publishing_event_processing_spec_helper.rb
+++ b/spec/support/publishing_event_processing_spec_helper.rb
@@ -30,7 +30,7 @@ module PublishingEventProcessingSpecHelper
       live: true,
       document_text: 'some content',
       phase: 'live',
-      organisation_id: org_content_id,
+      primary_organisation_id: org_content_id,
       primary_organisation_title: 'the-org',
       primary_organisation_withdrawn: false,
       publishing_app: 'calendars',


### PR DESCRIPTION
This is more reflective of what it actually means (the content_id of
the primary publishing organisation), and more consistent with the
other fields (like primary_organisation_title).

As the Content Data app expects organisation_id, these changes are
mostly internal, and the external changes should be compatible with
the Content Data Admin.

Once this has been deployed, and the Content Data Admin switched
across to use the primary_organisation_id, then the intermediate
changes can be removed.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* ~~Added/updated relevant documentation.~~
* [x] Added to Trello card.
