### PR TITLE
Make ga metric imports case insensitive

### DIFF
--- a/app/domain/etl/ga/internal_search_processor.rb
+++ b/app/domain/etl/ga/internal_search_processor.rb
@@ -50,7 +50,7 @@ private
         SELECT searches,
                dimensions_editions.id
         FROM events_gas, dimensions_editions
-        WHERE page_path = base_path
+        WHERE page_path = LOWER(base_path)
               AND events_gas.date = '#{date_to_s}'
       ) AS s
       WHERE dimensions_edition_id = s.id AND dimensions_date_id = '#{date_to_s}'

--- a/app/domain/etl/ga/user_feedback_processor.rb
+++ b/app/domain/etl/ga/user_feedback_processor.rb
@@ -52,7 +52,7 @@ private
                useful_yes,
                dimensions_editions.id
         FROM events_gas, dimensions_editions
-        WHERE page_path = base_path
+        WHERE page_path = LOWER(base_path)
               AND events_gas.date = '#{date_to_s}'
       ) AS s
       WHERE dimensions_edition_id = s.id AND dimensions_date_id = '#{date_to_s}'

--- a/app/domain/etl/ga/views_and_navigation_processor.rb
+++ b/app/domain/etl/ga/views_and_navigation_processor.rb
@@ -60,7 +60,7 @@ private
                page_time,
                dimensions_editions.id
         FROM events_gas, dimensions_editions
-        WHERE page_path = base_path
+        WHERE page_path = LOWER(base_path)
               AND events_gas.date = '#{date_to_s}'
       ) AS s
       WHERE dimensions_edition_id = s.id AND dimensions_date_id = '#{date_to_s}'

--- a/db/migrate/20190604105034_create_lower_index_on_base_path.rb
+++ b/db/migrate/20190604105034_create_lower_index_on_base_path.rb
@@ -1,0 +1,13 @@
+class CreateLowerIndexOnBasePath < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL
+    CREATE INDEX index_lower_base_path ON dimensions_editions (lower(base_path));
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+    DROP INDEX index_lower_base_path;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_111746) do
+ActiveRecord::Schema.define(version: 2019_06_04_105034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 2019_06_03_111746) do
     t.boolean "historical", null: false
     t.bigint "publishing_api_event_id"
     t.string "acronym"
+    t.index "lower((base_path)::text)", name: "index_lower_base_path"
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "live"], name: "index_dimensions_editions_on_content_id_and_live"
     t.index ["document_type"], name: "index_dimensions_editions_on_document_type"

--- a/spec/domain/etl/ga/internal_search_processor_spec.rb
+++ b/spec/domain/etl/ga/internal_search_processor_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Etl::GA::InternalSearchProcessor do
     before { allow(Etl::GA::InternalSearchService).to receive(:find_in_batches).and_yield(ga_response) }
 
     it "updates the facts with GA metrics" do
-      edition1 = create :edition, date: '2018-02-20', base_path: "/path1"
+      edition1 = create :edition, date: '2018-02-20', base_path: "/Path1"
+      #We have some mixed case paths so we need them to match the lowercase ones in GA
+
       fact1 = create :metric, edition: edition1, date: '2018-02-20'
       edition2 = create :edition, base_path: "/path2", date: '2018-02-20'
       fact2 = create :metric, edition: edition2, date: '2018-02-20'

--- a/spec/domain/etl/ga/user_feedback_processor_spec.rb
+++ b/spec/domain/etl/ga/user_feedback_processor_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Etl::GA::UserFeedbackProcessor do
     before { allow(Etl::GA::UserFeedbackService).to receive(:find_in_batches).and_yield(ga_response) }
 
     it 'update the facts with the GA metrics' do
-      edition1 = create :edition, base_path: '/path1', date: '2018-02-20'
+      edition1 = create :edition, base_path: '/Path1', date: '2018-02-20'
+      #We have some mixed case paths so we need them to match the lowercase ones in GA
+
       fact1 =  create :metric, edition: edition1, date: '2018-02-20', useful_no: 1, useful_yes: 2
       edition2 = create :edition, base_path: '/path2', date: '2018-02-20'
       fact2 =  create :metric, edition: edition2, date: '2018-02-20', useful_no: 20, useful_yes: 10

--- a/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
@@ -4,7 +4,9 @@ require 'traceable'
 RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
   subject { described_class }
 
-  let!(:edition1) { create :edition, base_path: '/path1', live: true, date: '2018-02-20' }
+  let!(:edition1) { create :edition, base_path: '/Path1', live: true, date: '2018-02-20' }
+  #We have some mixed case paths so we need them to match the lowercase ones in GA
+
   let!(:edition2) { create :edition, base_path: '/path2', live: true, date: '2018-02-20' }
 
   let(:date) { Date.new(2018, 2, 20) }


### PR DESCRIPTION
# What
Make the GA import processes case insensitive.

# Why

We are missing metrics from GA, this is because all data returned from GA has all lowercase 
`page_path` - data in content data has mixed case paths so they don't match.


Trello: https://trello.com/c/kCcLpI1m/967-3-bug-base-paths-with-uppercase-characters-get-no-metrics-from-google-analytics

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
