### PR TITLE
Add parent and sort fields

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -4,6 +4,8 @@ require 'json'
 class Dimensions::Edition < ApplicationRecord
   has_one :facts_edition, class_name: "Facts::Edition", foreign_key: :dimensions_edition_id
   belongs_to :publishing_api_event, class_name: "Events::PublishingApi", foreign_key: :publishing_api_event_id
+  belongs_to :parent, class_name: 'Dimensions::Edition', optional: true
+  has_many :children, class_name: 'Dimensions::Edition', foreign_key: 'parent_id'
   validates :content_id, presence: true
   validates :base_path, presence: true
   validates :schema_name, presence: true

--- a/db/migrate/20190612150721_add_parent_id_to_dimension_edition.rb
+++ b/db/migrate/20190612150721_add_parent_id_to_dimension_edition.rb
@@ -1,0 +1,7 @@
+class AddParentIdToDimensionEdition < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dimensions_editions, :parent_id, :integer, null: true
+
+    add_index :dimensions_editions, :parent_id, name: 'index_dim_edition_parent_id'
+  end
+end

--- a/db/migrate/20190613082656_add_sibling_order_to_dimensions_edition.rb
+++ b/db/migrate/20190613082656_add_sibling_order_to_dimensions_edition.rb
@@ -1,0 +1,5 @@
+class AddSiblingOrderToDimensionsEdition < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dimensions_editions, :sibling_order, :integer, null: true
+  end
+end

--- a/db/migrate/20190613112120_add_child_sort_order_to_dimensions_editions.rb
+++ b/db/migrate/20190613112120_add_child_sort_order_to_dimensions_editions.rb
@@ -1,0 +1,5 @@
+class AddChildSortOrderToDimensionsEditions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dimensions_editions, :child_sort_order, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_04_105034) do
+ActiveRecord::Schema.define(version: 2019_06_12_150721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,6 +89,7 @@ ActiveRecord::Schema.define(version: 2019_06_04_105034) do
     t.bigint "publishing_api_event_id"
     t.string "acronym"
     t.string "organisation_ids", default: [], array: true
+    t.integer "parent_id"
     t.index "lower((base_path)::text)", name: "index_lower_base_path"
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "live"], name: "index_dimensions_editions_on_content_id_and_live"
@@ -98,6 +99,7 @@ ActiveRecord::Schema.define(version: 2019_06_04_105034) do
     t.index ["live", "primary_organisation_id", "primary_organisation_title"], name: "index_dimensions_editions_on_latest_org_id_org_title"
     t.index ["live", "warehouse_item_id"], name: "index_dimensions_editions_on_live_and_warehouse_item_id", unique: true, where: "(live = true)"
     t.index ["live"], name: "index_dimensions_editions_on_live"
+    t.index ["parent_id"], name: "index_dim_edition_parent_id"
     t.index ["primary_organisation_id"], name: "index_dimensions_editions_organisation_id"
     t.index ["publishing_api_event_id"], name: "index_dimensions_editions_on_publishing_api_event_id"
     t.index ["warehouse_item_id", "base_path", "title", "document_type"], name: "index_for_content_query"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_12_150721) do
+ActiveRecord::Schema.define(version: 2019_06_13_082656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 2019_06_12_150721) do
     t.string "acronym"
     t.string "organisation_ids", default: [], array: true
     t.integer "parent_id"
+    t.integer "sibling_order"
     t.index "lower((base_path)::text)", name: "index_lower_base_path"
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "live"], name: "index_dimensions_editions_on_content_id_and_live"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_13_082656) do
+ActiveRecord::Schema.define(version: 2019_06_13_112120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2019_06_13_082656) do
     t.string "organisation_ids", default: [], array: true
     t.integer "parent_id"
     t.integer "sibling_order"
+    t.string "child_sort_order", array: true
     t.index "lower((base_path)::text)", name: "index_lower_base_path"
     t.index ["base_path"], name: "index_dimensions_editions_on_base_path"
     t.index ["content_id", "live"], name: "index_dimensions_editions_on_content_id_and_live"

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -177,6 +177,23 @@ RSpec.describe Dimensions::Edition, type: :model do
     end
   end
 
+  describe '#children' do
+    let(:parent) { create :edition, title: 'parent', base_path: '/parent' }
+    let!(:child) { create :edition, title: 'child', base_path: '/child', parent: parent }
+
+    it 'should return the parent' do
+      expect(child.parent).to eq(parent)
+    end
+
+    it 'returns nil if no parent' do
+      expect(parent.reload.parent).to be_nil
+    end
+
+    it 'returns the children' do
+      expect(parent.reload.children.to_a).to eq([child])
+    end
+  end
+
   describe '#parent_content_id' do
     it 'returns content_id of parent manual for a manual_section' do
       create :edition, content_id: 'the-parent', base_path: '/prefix-path/the-parent-path', document_type: 'manual'

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -177,20 +177,31 @@ RSpec.describe Dimensions::Edition, type: :model do
     end
   end
 
-  describe '#children' do
-    let(:parent) { create :edition, title: 'parent', base_path: '/parent' }
+  describe 'parent/child relationships' do
+    let(:child_sort_order) { %w[warehouse_item_id_1 warehouse_item_id_2] }
+    let(:parent) { create :edition, title: 'parent', base_path: '/parent', child_sort_order: child_sort_order }
     let!(:child) { create :edition, title: 'child', base_path: '/child', parent: parent }
 
-    it 'should return the parent' do
-      expect(child.parent).to eq(parent)
+    describe '#parent' do
+      it 'should return the parent' do
+        expect(child.parent).to eq(parent)
+      end
+
+      it 'returns nil if no parent' do
+        expect(parent.reload.parent).to be_nil
+      end
     end
 
-    it 'returns nil if no parent' do
-      expect(parent.reload.parent).to be_nil
+    describe '#children' do
+      it 'returns the children' do
+        expect(parent.reload.children.to_a).to eq([child])
+      end
     end
 
-    it 'returns the children' do
-      expect(parent.reload.children.to_a).to eq([child])
+    describe '#child_sort_order' do
+      it 'persists and retrieves child_sort_order' do
+        expect(parent.reload.child_sort_order).to eq(child_sort_order)
+      end
     end
   end
 


### PR DESCRIPTION
# Description
The basic model-level work for parent/child relationships.

Adds a `parent` and `sibling_order` columns to `dimensions_editions`.

Also adds `parent` and `children` relationships to `Dimensions::Edition`

Trello: https://trello.com/c/vwSC296q/1490-3-add-parent-child-attributes-to-dimensioneditions

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
