### PR TITLE
Add rake task to unset live on coming soon editions

### DIFF
--- a/lib/tasks/editions.rake
+++ b/lib/tasks/editions.rake
@@ -42,4 +42,14 @@ namespace :editions do
 
     puts "Done!"
   end
+
+  desc "Update live attribute for coming soon editions"
+  task unset_live_for_coming_soon_editions: :environment do
+    live_coming_soon_editions = Dimensions::Edition.live.where(document_type: 'coming_soon')
+    puts "Updating #{live_coming_soon_editions.count} live editions"
+
+    live_coming_soon_editions.update_all(live: false)
+
+    puts "Done!"
+  end
 end


### PR DESCRIPTION
Coming soon pages have been removed from the GOV.UK publishing platform.

These pages will have been unpublished, but the Publishing API did not correctly send a message to Content Data.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
