### PR TITLE
Parent/child relationships during streams processing for multi part messages

### DIFF
--- a/app/domain/streams/handlers/base_handler.rb
+++ b/app/domain/streams/handlers/base_handler.rb
@@ -1,10 +1,11 @@
 class Streams::Handlers::BaseHandler
   def update_editions(items_with_old_editions)
     publishing_api_event = Events::PublishingApi.new(payload: @payload, routing_key: @routing_key)
-    items_with_old_editions.each do |item|
-      if Streams::GrowDimension.should_grow? old_edition: item[:old_edition], attrs: item[:attrs]
-        update_edition(item[:attrs], item[:old_edition], publishing_api_event)
-      end
+    items_to_grow = items_with_old_editions.select do |item|
+      Streams::GrowDimension.should_grow? old_edition: item[:old_edition], attrs: item[:attrs]
+    end
+    items_to_grow.map do |item|
+      update_edition(item[:attrs], item[:old_edition], publishing_api_event)
     end
   end
 
@@ -15,5 +16,6 @@ private
     new_edition = Dimensions::Edition.new(attributes)
     new_edition.facts_edition = Etl::Edition::Processor.process(old_edition, new_edition)
     new_edition.promote!(old_edition)
+    new_edition
   end
 end

--- a/app/domain/streams/handlers/multipart_handler.rb
+++ b/app/domain/streams/handlers/multipart_handler.rb
@@ -12,10 +12,19 @@ class Streams::Handlers::MultipartHandler < Streams::Handlers::BaseHandler
   def process
     base_paths = attr_list.map { |hsh| hsh[:base_path] }
     deprecate_redundant_paths(base_paths)
-    update_editions(attr_list.map(&method(:find_old_edition)))
+    current_editions = update_editions(attr_list.map(&method(:find_old_edition)))
+    set_parent_relationships(current_editions)
   end
 
 private
+
+  def set_parent_relationships(editions)
+    parent = editions.first
+    children = editions.drop(1)
+    children.each do |child|
+      child.update_attributes(parent: parent)
+    end
+  end
 
   def find_old_edition(hash)
     old_edition = Dimensions::Edition.find_latest(hash[:warehouse_item_id])

--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -6,7 +6,7 @@ class Streams::Messages::BaseMessage
     @routing_key = routing_key
   end
 
-  def build_attributes(base_path:, title:, document_text:, warehouse_item_id:)
+  def build_attributes(base_path:, title:, document_text:, warehouse_item_id:, sibling_order: nil)
     {
       content_id: content_id,
       base_path: base_path,
@@ -25,6 +25,7 @@ class Streams::Messages::BaseMessage
       phase: @payload.fetch('phase', nil),
       publishing_app: @payload.fetch('publishing_app', nil),
       rendering_app: @payload.fetch('rendering_app', nil),
+      sibling_order: sibling_order,
       analytics_identifier: @payload.fetch('analytics_identifier', nil),
       update_type: @payload.fetch('update_type', nil),
       live: false,

--- a/app/domain/streams/messages/multipart_message.rb
+++ b/app/domain/streams/messages/multipart_message.rb
@@ -24,7 +24,8 @@ module Streams
           base_path: base_path_for_part(part, index),
           title: title_for(part),
           document_text: document_text_for_part(part['slug']),
-          warehouse_item_id: warehouse_item_id_for_part(part, index)
+          warehouse_item_id: warehouse_item_id_for_part(part, index),
+          sibling_order: index
         )
       end
     end

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -5,7 +5,7 @@ class Dimensions::Edition < ApplicationRecord
   has_one :facts_edition, class_name: "Facts::Edition", foreign_key: :dimensions_edition_id
   belongs_to :publishing_api_event, class_name: "Events::PublishingApi", foreign_key: :publishing_api_event_id
   belongs_to :parent, class_name: 'Dimensions::Edition', optional: true
-  has_many :children, class_name: 'Dimensions::Edition', foreign_key: 'parent_id'
+  has_many :children, -> { order('sibling_order') }, class_name: 'Dimensions::Edition', foreign_key: 'parent_id'
   validates :content_id, presence: true
   validates :base_path, presence: true
   validates :schema_name, presence: true

--- a/spec/domain/streams/messages/multipart_message_spec.rb
+++ b/spec/domain/streams/messages/multipart_message_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Streams::Messages::MultipartMessage do
           common_attributes.merge(
             warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}",
             document_text: 'Here 1',
+            sibling_order: 0,
             title: 'the-title: Part 1',
             base_path: '/base-path'
           ),
@@ -46,18 +47,21 @@ RSpec.describe Streams::Messages::MultipartMessage do
             warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part2",
             document_text: 'be 2',
             title: 'the-title: Part 2',
+            sibling_order: 1,
             base_path: '/base-path/part2'
           ),
           common_attributes.merge(
             warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part3",
             document_text: 'some 3',
             title: 'the-title: Part 3',
+            sibling_order: 2,
             base_path: '/base-path/part3'
           ),
           common_attributes.merge(
             warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part4",
             document_text: 'content 4.',
             title: 'the-title: Part 4',
+            sibling_order: 3,
             base_path: '/base-path/part4'
           )
         ])
@@ -84,18 +88,21 @@ RSpec.describe Streams::Messages::MultipartMessage do
             warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}",
             document_text: 'summary content',
             title: 'the-title: Summary',
+            sibling_order: 0,
             base_path: '/base-path'
           ),
           common_attributes.merge(
             warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part1",
             document_text: 'Here 1',
             title: 'the-title: Part 1',
+            sibling_order: 1,
             base_path: '/base-path/part1'
           ),
           common_attributes.merge(
             warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part2",
             document_text: 'be 2',
             title: 'the-title: Part 2',
+            sibling_order: 2,
             base_path: '/base-path/part2'
           )
         ])

--- a/spec/integration/streams/multiple/parent_child_spec.rb
+++ b/spec/integration/streams/multiple/parent_child_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe 'multi-part parent/child relationships' do
+  let(:content_id) { '8a5f749e-262c-4e4b-9d29-5da2b6349df7' }
+  let(:message) do
+    build :message,
+          :with_parts,
+          attributes: {
+            'content_id' => content_id,
+            'title' => 'Main Title',
+            'locale' => 'fr'
+          }
+  end
+  let(:subject) { Streams::Consumer.new }
+
+  it 'returns the children sorted by sort order' do
+    subject.process(message)
+    parent = Dimensions::Edition.find_latest("#{content_id}:fr")
+    expected = [
+     ["#{content_id}:fr:part2", 1],
+     ["#{content_id}:fr:part3", 2],
+     ["#{content_id}:fr:part4", 3]
+    ]
+    expect(parent.children.pluck(:warehouse_item_id, :sibling_order)).to eq(expected)
+  end
+end

--- a/spec/support/publishing_event_processing_spec_helper.rb
+++ b/spec/support/publishing_event_processing_spec_helper.rb
@@ -47,6 +47,7 @@ module PublishingEventProcessingSpecHelper
       public_updated_at: "2018-04-20T12:00:40+01:00",
       first_published_at: "2018-04-19T12:00:40+01:00",
       withdrawn: false,
+      sibling_order: nil,
       historical: false,
       live: false
     ).merge(overrides)


### PR DESCRIPTION
# Description
Add parent/child relationships and sibling sort order during streams processing.

This cover multi-part documents (guides, travel advice)

Trello: https://trello.com/c/cBmiTJjc/1497-5-add-streams-processing-and-rake-task-to-populate-parent-child-relationships