### PR TITLE
Add documents children endpoint

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,9 @@
 class Api::NotFoundError < StandardError
 end
 
+class Api::ParentNotFoundError < StandardError
+end
+
 class Api::BaseController < ApplicationController
   before_action :set_cache_headers
 
@@ -14,6 +17,10 @@ class Api::BaseController < ApplicationController
 
   rescue_from(Api::NotFoundError) do
     not_found_response
+  end
+
+  rescue_from(Api::ParentNotFoundError) do
+    parent_not_found_response
   end
 
   def validate_params!
@@ -63,6 +70,14 @@ private
       type: "https://content-performance-api.publishing.service.gov.uk/errors.html#base-path-not-found",
       title: 'The base path you are looking for cannot be found',
       invalid_params: %w[base_path]
+    }
+    render json: response_hash, status: 404, content_type: "application/problem+json"
+  end
+
+  def parent_not_found_response
+    response_hash = {
+      title: 'The parent document you are looking for cannot be found',
+      invalid_params: %w[document_id]
     }
     render json: response_hash, status: 404, content_type: "application/problem+json"
   end

--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -1,0 +1,26 @@
+class Api::DocumentsController < Api::BaseController
+  def children
+    @document_id = params[:document_id]
+
+    parent = find_parent_edition!
+
+    @documents = Finders::DocumentChildren.call(parent, api_request.to_filter)
+  end
+
+private
+
+  def api_request
+    @api_request ||= Api::DocumentChildrenRequest.new(permitted_params)
+  end
+
+  def permitted_params
+    params.permit(:document_id, :time_period, :sort, :format)
+  end
+
+  def find_parent_edition!
+    parent = Dimensions::Edition.live.where(warehouse_item_id: @document_id).first
+    raise Api::ParentNotFoundError.new("#{params[:document_id]} not found") if parent.nil?
+
+    parent
+  end
+end

--- a/app/domain/api/document_children_request.rb
+++ b/app/domain/api/document_children_request.rb
@@ -1,0 +1,48 @@
+class Api::DocumentChildrenRequest
+  VAILD_SORT_KEYS = (Metric.daily_metrics.map(&:name) + %w[title document_type sibling_order]).freeze
+  VALID_SORT_DIRECTIONS = %w[asc desc].freeze
+  VALID_TIME_PERIODS = ['past-30-days', 'last-month', 'past-3-months', 'past-6-months', 'past-year'].freeze
+  include ActiveModel::Validations
+
+  validate :valid_time_period
+  validate :valid_sort_key
+  validate :valid_sort_direction
+
+
+  def initialize(params)
+    @time_period = params[:time_period]
+    @sort_key, @sort_direction = parse_sort_parameter(params[:sort])
+  end
+
+  def to_filter
+    {
+      time_period: @time_period,
+      sort_key: @sort_key,
+      sort_direction: @sort_direction
+    }
+  end
+
+private
+
+  def parse_sort_parameter(sort_param)
+    sort_param.present? ? sort_param.split(':', 2) : [nil, nil]
+  end
+
+  def valid_sort_key
+    return true if @sort_key.in?(VAILD_SORT_KEYS) || @sort_key.nil?
+
+    errors.add('sort', 'this is not a valid sort key')
+  end
+
+  def valid_sort_direction
+    return true if @sort_direction.in?(VALID_SORT_DIRECTIONS) || @sort_direction.nil?
+
+    errors.add('sort', 'this is not a valid sort direction')
+  end
+
+  def valid_time_period
+    return true if @time_period.in?(VALID_TIME_PERIODS) || @time_period.blank?
+
+    errors.add('time_period', 'this is not a valid time period')
+  end
+end

--- a/app/domain/finders/document_children.rb
+++ b/app/domain/finders/document_children.rb
@@ -1,0 +1,55 @@
+class Finders::DocumentChildren
+  EDITION_COLUMNS = %w(base_path title primary_organisation_id document_type sibling_order).freeze
+  AGGREGATION_COLUMNS = %w(upviews pviews useful_yes useful_no satisfaction searches feedex).freeze
+
+  def self.call(*args)
+    new(*args).results
+  end
+
+  def results
+    filter_editions
+      .order(sanitized_order(@sort_key, @sort_dir))
+      .select(*columns)
+  end
+
+private
+
+  def initialize(parent_edition, filters)
+    @parent_edition = parent_edition
+    @time_period = filters.fetch(:time_period)
+    @sort_key = filters.fetch(:sort_key) || 'sibling_order'
+    @sort_dir = filters.fetch(:sort_direction) || 'asc'
+  end
+
+  def filter_editions
+    scope = @parent_edition.children
+    scope = scope.or(Dimensions::Edition.where(id: @parent_edition.id))
+    scope = scope.joins(join_query)
+    scope
+  end
+
+  def join_query
+    "LEFT JOIN aggregations_search_#{view[:table_name]} a ON dimensions_editions.warehouse_item_id = a.warehouse_item_id"
+  end
+
+  def view
+    @view ||= Finders::SelectView.new(@time_period).run
+  end
+
+  def columns
+    AGGREGATION_COLUMNS + (EDITION_COLUMNS.map { |c| "dimensions_editions.#{c}" })
+  end
+
+  def sanitized_order(column, direction)
+    avaliable_columns = AGGREGATION_COLUMNS + EDITION_COLUMNS
+
+    raise "Order atrribute of #{column} not permitted." unless avaliable_columns.include?(column.to_s)
+    raise "Order direction of #{direction} not permitted." unless %w[ASC DESC].include?(direction.upcase)
+
+    if column == 'sibling_order'
+      "#{column} #{direction} NULLS FIRST, title #{direction}"
+    else
+      "#{column} #{direction} NULLS LAST, sibling_order ASC NULLS FIRST"
+    end
+  end
+end

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -5,7 +5,7 @@ class Dimensions::Edition < ApplicationRecord
   has_one :facts_edition, class_name: "Facts::Edition", foreign_key: :dimensions_edition_id
   belongs_to :publishing_api_event, class_name: "Events::PublishingApi", foreign_key: :publishing_api_event_id
   belongs_to :parent, class_name: 'Dimensions::Edition', optional: true
-  has_many :children, -> { order('sibling_order') }, class_name: 'Dimensions::Edition', foreign_key: 'parent_id'
+  has_many :children, -> { where(live: true) }, class_name: 'Dimensions::Edition', foreign_key: 'parent_id'
   validates :content_id, presence: true
   validates :base_path, presence: true
   validates :schema_name, presence: true

--- a/app/views/api/documents/children.json.jbuilder
+++ b/app/views/api/documents/children.json.jbuilder
@@ -1,0 +1,14 @@
+json.documents @documents do |document|
+  json.base_path document.base_path
+  json.title document.title
+  json.primary_organisation_id document.primary_organisation_id
+  json.document_type document.document_type
+  json.sibling_order document.sibling_order
+  json.upviews document.upviews
+  json.pviews document.pviews
+  json.feedex document.feedex
+  json.useful_yes document.useful_yes
+  json.useful_no document.useful_no
+  json.satisfaction document.satisfaction
+  json.searches document.searches
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     get '/v1/healthcheck', to: "healthcheck#index"
     get '/v1/organisations', to: 'organisations#index'
     get '/v1/document_types', to: 'document_types#index'
+    get '/v1/documents/:document_id/children', to: 'documents#children'
   end
 
   get '/content', to: 'content#show', defaults: { format: :json }

--- a/spec/domain/api/document_children_request_spec.rb
+++ b/spec/domain/api/document_children_request_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe Api::DocumentChildrenRequest do
+  let(:params) { { time_period: 'past-30-days' } }
+
+  describe '#to_filter' do
+    it 'returns a hash with the parameters' do
+      request = described_class.new(time_period: 'past-30-days', sort: 'feedex:asc')
+
+      expect(request.to_filter).to eq(
+        time_period: 'past-30-days',
+        sort_key: 'feedex',
+        sort_direction: 'asc'
+      )
+    end
+
+    it 'includes missing parameters' do
+      request = described_class.new({})
+
+      expect(request.to_filter).to eq(
+        time_period: nil,
+        sort_key: nil,
+        sort_direction: nil
+      )
+    end
+
+    allowed_sort_keys = %w[
+      title document_type sibling_order upviews pviews useful_yes useful_no searches feedex
+    ]
+
+    allowed_sort_keys.each do |key|
+      it "allows #{key} as sort key" do
+        request = described_class.new(params.merge(sort: key))
+
+        expect(request.to_filter).to include(sort_key: key, sort_direction: nil)
+      end
+    end
+
+    it 'allows a valid sort key with asc direction' do
+      request = described_class.new(params.merge(sort: 'feedex:asc'))
+
+      expect(request.to_filter).to include(sort_key: 'feedex', sort_direction: 'asc')
+    end
+
+    it 'allows a valid sort key with desc direction' do
+      request = described_class.new(params.merge(sort: 'feedex:desc'))
+
+      expect(request.to_filter).to include(sort_key: 'feedex', sort_direction: 'desc')
+    end
+
+    describe '#sort_key' do
+      it 'validates value' do
+        request = described_class.new(params.merge(sort: 'invalid'))
+        request.valid?
+        expect(request.errors[:sort]).to include("this is not a valid sort key")
+      end
+
+      it 'validates presence' do
+        request = described_class.new(params.merge(sort: ':desc'))
+        request.valid?
+        expect(request.errors[:sort]).to include("this is not a valid sort key")
+      end
+    end
+
+    describe '#sort_direction' do
+      it 'validates value' do
+        request = described_class.new(params.merge(sort: 'feedex:invalid'))
+        request.valid?
+        expect(request.errors[:sort]).to include("this is not a valid sort direction")
+      end
+
+      it 'validates presence' do
+        request = described_class.new(params.merge(sort: 'feedex:'))
+        request.valid?
+        expect(request.errors[:sort]).to include("this is not a valid sort direction")
+      end
+    end
+  end
+end

--- a/spec/domain/finders/document_children_spec.rb
+++ b/spec/domain/finders/document_children_spec.rb
@@ -1,0 +1,293 @@
+RSpec.describe Finders::DocumentChildren do
+  include AggregationsSupport
+
+  let(:time_period) { 'past-30-days' }
+  let(:sort_key) { nil }
+  let(:sort_direction) { nil }
+  let(:filters) do
+    {
+      time_period: time_period,
+      sort_key: sort_key,
+      sort_direction: sort_direction
+    }
+  end
+
+  subject { described_class }
+
+  before do
+    create :user
+  end
+
+  it 'returns the aggregations for the past 30 days' do
+    parent = create :edition, date: 2.months.ago, primary_organisation_id: '1', document_type: 'manual'
+    child = create :edition, date: 2.months.ago, parent: parent
+
+    create :metric, edition: parent, date: 15.days.ago, upviews: 15, useful_yes: 1, useful_no: 1, searches: 10
+    create :metric, edition: parent, date: 10.days.ago, upviews: 20, useful_yes: 24, useful_no: 74, searches: 1
+    create :metric, edition: child, date: 10.days.ago, upviews: 15, useful_yes: 1, useful_no: 1, searches: 10
+    create :metric, edition: child, date: 11.days.ago, upviews: 10, useful_yes: 74, useful_no: 24, searches: 11
+
+    recalculate_aggregations!
+
+    response = records_to_hash(subject.call(parent, filters))
+
+    expect(response).to contain_exactly(
+      hash_including(upviews: 35, searches: 11, satisfaction: 0.25),
+      hash_including(upviews: 25, searches: 21, satisfaction: 0.75),
+    )
+  end
+
+  it 'returns the edition attributes' do
+    parent = create(
+      :edition,
+      title: 'parent',
+      base_path: '/parent',
+      date: 2.months.ago,
+      primary_organisation_id: '1',
+      document_type: 'manual'
+    )
+
+    child = create(
+      :edition,
+      title: 'child',
+      base_path: '/child',
+      date: 2.months.ago,
+      primary_organisation_id: '2',
+      document_type: 'manual_section',
+      sibling_order: 1,
+      parent: parent
+    )
+
+    create :metric, edition: parent, date: 15.days.ago
+    create :metric, edition: child, date: 10.days.ago
+
+    recalculate_aggregations!
+
+    response = records_to_hash(subject.call(parent, filters))
+
+    expect(response).to contain_exactly(
+      hash_including(
+        title: 'parent',
+        base_path: '/parent',
+        primary_organisation_id: '1',
+        document_type: 'manual',
+        sibling_order: nil
+      ),
+      hash_including(
+        title: 'child',
+        base_path: '/child',
+        primary_organisation_id: '2',
+        document_type: 'manual_section',
+        sibling_order: 1
+      )
+    )
+  end
+
+  context 'Newly created child edition before ETL process runs' do
+    it 'returns edition attribute for latest editions' do
+      parent = create :edition, title: 'parent', date: 2.months.ago
+      old_child = create :edition, title: 'old', date: 10.days.ago, parent: parent
+
+      create :metric, edition: parent, date: 15.days.ago, upviews: 1
+      create :metric, edition: old_child, date: 10.days.ago, upviews: 2
+
+      recalculate_aggregations!
+
+      create :edition, title: 'new', date: 10.days.ago, parent: parent, replaces: old_child
+
+      response = records_to_hash(subject.call(parent, filters))
+
+      expect(response).to contain_exactly(hash_including(title: 'parent', upviews: 1), hash_including(title: 'new', upviews: 2))
+    end
+  end
+
+  context 'Newly created parent edition before ETL process runs' do
+    it 'returns edition attribute for latest editions' do
+      parent = create :edition, title: 'old', date: 2.months.ago
+      child = create :edition, date: 10.days.ago, parent: parent, title: 'child'
+
+      create :metric, edition: parent, date: 15.days.ago, upviews: 1
+      create :metric, edition: child, date: 10.days.ago, upviews: 2
+
+      recalculate_aggregations!
+
+      new_parent = create :edition, title: 'new', date: 10.days.ago, replaces: parent
+      child.update(parent: new_parent)
+
+      response = records_to_hash(subject.call(new_parent, filters))
+
+      expect(response).to contain_exactly(hash_including(title: 'new', upviews: 1), hash_including(title: 'child', upviews: 2))
+    end
+  end
+
+  describe 'Other date ranges' do
+    let(:parent) { create :edition, date: 12.months.ago }
+    subject { records_to_hash(described_class.call(parent, filters)) }
+
+    context 'when time period is last month' do
+      let(:time_period) { 'last-month' }
+      it 'returns the aggregations for last month' do
+        last_month_date = (Date.today - 1.month)
+        child = create :edition, date: 2.months.ago, parent: parent
+
+        create :metric, edition: parent, date: last_month_date, upviews: 1, useful_yes: 3, useful_no: 1, searches: 10
+        create :metric, edition: child, date: last_month_date, upviews: 2, useful_yes: 1, useful_no: 3, searches: 20
+
+        recalculate_aggregations!
+
+        expect(subject).to contain_exactly(
+          hash_including(upviews: 1, searches: 10, satisfaction: 0.75),
+          hash_including(upviews: 2, searches: 20, satisfaction: 0.25),
+        )
+      end
+    end
+
+    context 'when time period is past 3 months' do
+      let(:time_period) { 'past-3-months' }
+      it 'returns the aggregations for past 3 months' do
+        date = (Date.today - 2.month)
+        child = create :edition, date: 2.months.ago, parent: parent
+
+        create :metric, edition: parent, date: date, upviews: 1, useful_yes: 3, useful_no: 1, searches: 10
+        create :metric, edition: child, date: date, upviews: 2, useful_yes: 1, useful_no: 3, searches: 20
+
+        recalculate_aggregations!
+
+        expect(subject).to contain_exactly(
+          hash_including(upviews: 1, searches: 10, satisfaction: 0.75),
+          hash_including(upviews: 2, searches: 20, satisfaction: 0.25),
+        )
+      end
+    end
+
+    context 'when time period is past 6 months' do
+      let(:time_period) { 'past-6-months' }
+      it 'returns the aggregations for past 6 months' do
+        date = (Date.today - 5.month)
+        child = create :edition, date: 6.months.ago, parent: parent
+
+        create :metric, edition: parent, date: date, upviews: 1, useful_yes: 3, useful_no: 1, searches: 10
+        create :metric, edition: child, date: date, upviews: 2, useful_yes: 1, useful_no: 3, searches: 20
+
+        recalculate_aggregations!
+
+        expect(subject).to contain_exactly(
+          hash_including(upviews: 1, searches: 10, satisfaction: 0.75),
+          hash_including(upviews: 2, searches: 20, satisfaction: 0.25),
+        )
+      end
+    end
+
+    context 'when time period is past year' do
+      let(:time_period) { 'past-year' }
+      it 'returns the aggregations for past year' do
+        date = (Date.today - 12.month)
+        child = create :edition, date: 12.months.ago, parent: parent
+
+        create :metric, edition: parent, date: date, upviews: 1, useful_yes: 3, useful_no: 1, searches: 10
+        create :metric, edition: child, date: date, upviews: 2, useful_yes: 1, useful_no: 3, searches: 20
+
+        recalculate_aggregations!
+
+        expect(subject).to contain_exactly(
+          hash_including(upviews: 1, searches: 10, satisfaction: 0.75),
+          hash_including(upviews: 2, searches: 20, satisfaction: 0.25),
+        )
+      end
+    end
+  end
+
+  describe 'Order' do
+    let(:parent) { create :edition, title: 'A' }
+
+    before do
+      edition1 = create :edition, title: 'B', sibling_order: 1, parent: parent
+      edition2 = create :edition, title: 'C', sibling_order: 2, parent: parent
+
+      create :metric, edition: parent, date: 15.days.ago, upviews: 1, feedex: 2, useful_yes: 1, useful_no: 0
+      create :metric, edition: edition1, date: 15.days.ago, upviews: 1, feedex: 1, useful_yes: 0, useful_no: 1
+      create :metric, edition: edition2, date: 15.days.ago, upviews: 1, feedex: 3, useful_yes: 0, useful_no: 0
+      recalculate_aggregations!
+    end
+
+    context 'when the sort key is upviews' do
+      let(:sort_key) { 'upviews' }
+
+      context 'and sort is ascending direction' do
+        let(:sort_direction) { 'asc' }
+
+        it 'secondary sorts on sibling order asc' do
+          response = records_to_hash(subject.call(parent, filters))
+
+          titles = response.map { |result| result.fetch(:title) }
+          expect(titles).to eq(%w(A B C))
+        end
+      end
+
+      context 'and sort is desc direction' do
+        let(:sort_direction) { 'desc' }
+
+        it 'secondary sorts on sibling order asc' do
+          response = records_to_hash(subject.call(parent, filters))
+
+          titles = response.map { |result| result.fetch(:title) }
+          expect(titles).to eq(%w(A B C))
+        end
+      end
+    end
+
+    context 'when the sort key feedex' do
+      let(:sort_key) { 'feedex' }
+
+      context 'and sort is ascending direction' do
+        let(:sort_direction) { 'asc' }
+
+        it 'secondary sorts on feedex ascending' do
+          response = records_to_hash(subject.call(parent, filters))
+
+          titles = response.map { |result| result.fetch(:title) }
+          expect(titles).to eq(%w(B A C))
+        end
+      end
+
+      context 'and sort is descending direction' do
+        let(:sort_direction) { 'desc' }
+
+        it 'secondary sorts on feedex ascending' do
+          response = records_to_hash(subject.call(parent, filters))
+
+          titles = response.map { |result| result.fetch(:title) }
+          expect(titles).to eq(%w(C A B))
+        end
+      end
+    end
+
+    context 'when the sort key satisfaction' do
+      let(:sort_key) { 'satisfaction' }
+
+      context 'when sort is ascending direction' do
+        let(:sort_direction) { 'asc' }
+        it 'orders NULL last when in ascending direction' do
+          response = records_to_hash(subject.call(parent, filters))
+          titles = response.map { |result| result.fetch(:title) }
+          expect(titles).to eq(%w(B A C))
+        end
+      end
+
+      context 'when sort is ascending direction' do
+        let(:sort_direction) { 'desc' }
+        it 'orders NULL last when in descending direction' do
+          response = records_to_hash(subject.call(parent, filters))
+
+          titles = response.map { |result| result.fetch(:title) }
+          expect(titles).to eq(%w(A B C))
+        end
+      end
+    end
+  end
+end
+
+def records_to_hash(records)
+  records.to_a.map { |e| e.serializable_hash.deep_symbolize_keys }
+end
+

--- a/spec/domain/finders/document_children_spec.rb
+++ b/spec/domain/finders/document_children_spec.rb
@@ -290,4 +290,3 @@ end
 def records_to_hash(records)
   records.to_a.map { |e| e.serializable_hash.deep_symbolize_keys }
 end
-

--- a/spec/factories/editions.rb
+++ b/spec/factories/editions.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :edition, class: Dimensions::Edition do
     live { true }
     locale { 'en' }
+    parent { nil }
     sequence(:content_id) { SecureRandom.uuid }
     sequence(:title) { |i| "title - #{i}" }
     sequence(:base_path) { |i| "/base-path-#{i}" }
@@ -15,6 +16,7 @@ FactoryBot.define do
     withdrawn { false }
     historical { false }
     association :publishing_api_event
+    sibling_order { nil }
 
     transient do
       date { Time.zone.today }

--- a/spec/integration/streams/multiple/parent_child_spec.rb
+++ b/spec/integration/streams/multiple/parent_child_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'multi-part parent/child relationships' do
   end
   let(:subject) { Streams::Consumer.new }
 
-  it 'returns the children sorted by sort order' do
+  it 'returns the children' do
     subject.process(message)
     parent = Dimensions::Edition.find_latest("#{content_id}:fr")
     expected = [
@@ -19,7 +19,7 @@ RSpec.describe 'multi-part parent/child relationships' do
      ["#{content_id}:fr:part3", 2],
      ["#{content_id}:fr:part4", 3]
     ]
-    expect(parent.children.pluck(:warehouse_item_id, :sibling_order)).to eq(expected)
+    expect(parent.children.pluck(:warehouse_item_id, :sibling_order)).to include(*expected)
   end
 
   it 'resets the parent of existing unchanged items' do
@@ -33,7 +33,7 @@ RSpec.describe 'multi-part parent/child relationships' do
       ["#{content_id}:fr:part3", 2],
       ["#{content_id}:fr:part4", 3]
     ]
-    expect(parent.children.pluck(:warehouse_item_id, :sibling_order)).to eq(expected)
+    expect(parent.children.pluck(:warehouse_item_id, :sibling_order)).to include(*expected)
   end
 
   it 'does not reset the parent of old items' do

--- a/spec/requests/api/v1/documents_spec.rb
+++ b/spec/requests/api/v1/documents_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe '/api/v1/documents/:document_id/children', type: :request do
+  include AggregationsSupport
+
+  before { create(:user) }
+  let(:content_id) { SecureRandom.uuid }
+  let(:locale) { 'en' }
+  let(:time_period) { 'past-30-days' }
+
+  describe "documents show" do
+    it "describes a documents with no children" do
+      _, parent_response = setup_edition_and_metrics(content_id, locale, 10)
+
+      get "/api/v1/documents/#{content_id}:#{locale}/children?time_period=#{time_period}"
+
+      json = JSON.parse(response.body)
+
+      expect(json).to include("documents" => [parent_response])
+    end
+
+    it "describes a documents with children" do
+      parent, parent_response = setup_edition_and_metrics(content_id, locale, 10)
+      _, child1_response = setup_edition_and_metrics(SecureRandom.uuid, locale, 11, parent: parent, order: 1)
+      _, child2_response = setup_edition_and_metrics(SecureRandom.uuid, locale, 12, parent: parent, order: 2)
+
+      get "/api/v1/documents/#{content_id}:#{locale}/children?time_period=#{time_period}"
+
+      json = JSON.parse(response.body)
+
+      expect(json).to include("documents" => [parent_response, child1_response, child2_response])
+    end
+
+    it "describes the children documents when parent does not exist" do
+      get "/api/v1/documents/wrong-id:en/children?time_period=#{time_period}"
+
+      json = JSON.parse(response.body)
+
+      expect(json).to include(
+        "title" => "The parent document you are looking for cannot be found",
+        "invalid_params" => %w(document_id)
+      )
+
+      expect(response).to have_http_status(404)
+    end
+  end
+end
+
+def setup_edition_and_metrics(content_id, locale, total_upviews, parent: nil, order: nil)
+  edition = create :edition, content_id: content_id, locale: locale, live: true, parent: parent, sibling_order: order
+
+  create :metric, edition: edition, date: Date.yesterday, upviews: 0, pviews: 1, useful_yes: 1, useful_no: 1, searches: 1
+  create :metric, edition: edition, date: 10.days.ago, upviews: total_upviews, pviews: 1, useful_yes: 74, useful_no: 24, searches: 2
+
+  recalculate_aggregations!
+
+  response = {
+    "base_path" => edition.base_path,
+    "title" => edition.title,
+    "primary_organisation_id" => edition.primary_organisation_id,
+    "document_type" => edition.document_type,
+    "sibling_order" => order,
+    "upviews" => total_upviews,
+    "pviews" => 2,
+    "feedex" => 0,
+    "useful_yes" => 75,
+    "useful_no" => 25,
+    "satisfaction" => 0.75,
+    "searches" => 3
+  }
+  [edition, response]
+end

--- a/spec/routing/documents_routing_spec.rb
+++ b/spec/routing/documents_routing_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe 'documents endpoint routing' do
+  it 'routes /documents/1234/children' do
+    expect(get: 'api/v1/documents/1234/children').to route_to(
+      controller: 'api/documents',
+      action: 'children',
+      format: :json,
+      document_id: '1234'
+     )
+  end
+end


### PR DESCRIPTION
This commit adds the controller, view, route to enable to the /documents/:document_id/children endpoint. This endpoint responds with information and metrics about a given parent document and its children.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
