### PR TITLE
Parent child relationships for html publications

### DIFF
--- a/app/domain/streams/grow_dimension.rb
+++ b/app/domain/streams/grow_dimension.rb
@@ -37,6 +37,15 @@ private
   end
 
   def excluded_from_comparison?(key, _value)
-    %i[publishing_api_payload_version public_updated_at id update_at created_at live warehouse_item_id publishing_api_event_id].include? key
+    %i[publishing_api_payload_version
+       public_updated_at
+       id
+       update_at
+       created_at
+       live
+       warehouse_item_id
+       publishing_api_event_id
+       parent_warehouse_id
+       sibling_order].include? key
   end
 end

--- a/app/domain/streams/handlers/base_handler.rb
+++ b/app/domain/streams/handlers/base_handler.rb
@@ -4,7 +4,7 @@ class Streams::Handlers::BaseHandler
     items_to_grow = items_with_old_editions.select do |item|
       Streams::GrowDimension.should_grow? old_edition: item[:old_edition], attrs: item[:attrs]
     end
-    items_to_grow.map do |item|
+    items_to_grow.each do |item|
       update_edition(item[:attrs], item[:old_edition], publishing_api_event)
     end
   end

--- a/app/domain/streams/handlers/base_handler.rb
+++ b/app/domain/streams/handlers/base_handler.rb
@@ -12,10 +12,12 @@ class Streams::Handlers::BaseHandler
 private
 
   def update_edition(new_edition_attr, old_edition, publishing_api_event)
-    attributes = new_edition_attr.merge(publishing_api_event: publishing_api_event)
+    parent_warehouse_id = new_edition_attr[:parent_warehouse_id]
+    attributes = new_edition_attr.except(:parent_warehouse_id).merge(publishing_api_event: publishing_api_event)
     new_edition = Dimensions::Edition.new(attributes)
     new_edition.facts_edition = Etl::Edition::Processor.process(old_edition, new_edition)
     new_edition.promote!(old_edition)
+    Streams::ParentChild::LinksProcessor.update_parent_and_sort_siblings(new_edition, parent_warehouse_id)
     new_edition
   end
 end

--- a/app/domain/streams/handlers/multipart_handler.rb
+++ b/app/domain/streams/handlers/multipart_handler.rb
@@ -12,19 +12,10 @@ class Streams::Handlers::MultipartHandler < Streams::Handlers::BaseHandler
   def process
     base_paths = attr_list.map { |hsh| hsh[:base_path] }
     deprecate_redundant_paths(base_paths)
-    current_editions = update_editions(attr_list.map(&method(:find_old_edition)))
-    set_parent_relationships(current_editions)
+    update_editions(attr_list.map(&method(:find_old_edition)))
   end
 
 private
-
-  def set_parent_relationships(editions)
-    parent = editions.first
-    children = editions.drop(1)
-    children.each do |child|
-      child.update_attributes(parent: parent)
-    end
-  end
 
   def find_old_edition(hash)
     old_edition = Dimensions::Edition.find_latest(hash[:warehouse_item_id])

--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -7,6 +7,11 @@ class Streams::Messages::BaseMessage
   end
 
   def build_attributes(base_path:, title:, document_text:, warehouse_item_id:, sibling_order: nil)
+    parser = Streams::ParentChild::Parser.new
+    parent_child_attrs = {
+      parent_warehouse_id: parser.get_parent_id(payload),
+      child_sort_order: parser.get_children_ids(payload)
+    }.compact
     {
       content_id: content_id,
       base_path: base_path,
@@ -32,7 +37,7 @@ class Streams::Messages::BaseMessage
       warehouse_item_id: warehouse_item_id,
       withdrawn: withdrawn_notice?,
       historical: historically_political?,
-    }
+    }.merge(parent_child_attrs)
   end
 
   def invalid?

--- a/app/domain/streams/messages/multipart_message.rb
+++ b/app/domain/streams/messages/multipart_message.rb
@@ -19,7 +19,7 @@ module Streams
     end
 
     def edition_attributes
-      parts.map.with_index do |part, index|
+      attrs = parts.map.with_index do |part, index|
         build_attributes(
           base_path: base_path_for_part(part, index),
           title: title_for(part),
@@ -28,6 +28,11 @@ module Streams
           sibling_order: index
         )
       end
+      parent = attrs.first
+      children = attrs.drop(1)
+      parent[:child_sort_order] = children.map { |h| h[:warehouse_item_id] }
+      children.each { |h| h[:parent_warehouse_id] = parent[:warehouse_item_id] }
+      attrs
     end
 
   private

--- a/app/domain/streams/parent_child/links_processor.rb
+++ b/app/domain/streams/parent_child/links_processor.rb
@@ -1,0 +1,39 @@
+class Streams::ParentChild::LinksProcessor
+  def self.update_parent_and_sort_siblings(edition, parent_warehouse_id)
+    new(edition, parent_warehouse_id).update_parent_and_sort_siblings
+  end
+
+  def initialize(edition, parent_warehouse_id)
+    @edition = edition
+    @parent_warehouse_id = parent_warehouse_id
+  end
+
+  def update_parent_and_sort_siblings
+    children = get_children
+    update_parent_and_sort(children) unless children.empty?
+    parent = get_parent
+    Streams::ParentChild::LinksProcessor.update_parent_and_sort_siblings(parent, nil) unless parent.nil?
+  end
+
+private
+
+  attr_reader :edition, :parent_warehouse_id
+
+  def get_children
+    Dimensions::Edition.where(warehouse_item_id: edition.child_sort_order, live: true)
+  end
+
+  def get_parent
+    Dimensions::Edition.where(warehouse_item_id: parent_warehouse_id).first
+  end
+
+  def update_parent_and_sort(children)
+    children.each do |child|
+      child.update_attributes(parent: @edition, sibling_order: sort_order_for(child.warehouse_item_id))
+    end
+  end
+
+  def sort_order_for(warehouse_item_id)
+    edition.child_sort_order.find_index(warehouse_item_id) + 1
+  end
+end

--- a/app/domain/streams/parent_child/parent_child_links_parser.rb
+++ b/app/domain/streams/parent_child/parent_child_links_parser.rb
@@ -1,0 +1,42 @@
+class Streams::ParentChild::ParentChildLinksParser
+  DOCUMENT_TYPES = %w[
+      guidance
+      form
+      foi_release
+      promotional
+      html_publication
+      notice
+      correspondence
+      research
+      official_statistics
+      transparency
+      statutory_guidance
+      independent_report
+      national_statistics
+      corporate_report
+      policy_paper
+      decision
+      map
+      regulation
+      international_treaty
+      impact_assessment
+      imported
+    ].freeze
+
+  def self.get_children_ids(payload)
+    children = payload.dig('links', 'children') || []
+
+    children.map { |h| to_warehouse_id(h['content_id'], h['locale']) }
+  end
+
+  def self.get_parent_id(payload)
+    parent_array = payload.dig('links', 'parent')
+    return nil if parent_array.blank?
+
+    to_warehouse_id(parent_array.first['content_id'], parent_array.first['locale'])
+  end
+
+  def self.to_warehouse_id(content_id, locale)
+    "#{content_id}:#{locale}"
+  end
+end

--- a/app/domain/streams/parent_child/parser.rb
+++ b/app/domain/streams/parent_child/parser.rb
@@ -1,0 +1,43 @@
+class Streams::ParentChild::Parser
+  PARSERS = [
+    ::Streams::ParentChild::ParentChildLinksParser
+  ].freeze
+
+  def get_parent_id(payload)
+    parser = parsers[payload['document_type']]
+    return nil if parser.nil?
+
+    parser.get_parent_id(payload)
+  end
+
+  def get_children_ids(payload)
+    parser = parsers[payload['document_type']]
+    return nil if parser.nil?
+
+    parser.get_children_ids(payload)
+  end
+
+  def initialize
+    register_parsers
+  end
+
+  def create_parser(document_type)
+    parsers[document_type]
+  end
+
+private
+
+  def register_parsers
+    PARSERS.each(&method(:register_parser))
+  end
+
+  def register_parser(parser_class)
+    parser_class::DOCUMENT_TYPES.each do |document_type|
+      parsers[document_type] = parser_class
+    end
+  end
+
+  def parsers
+    @parsers ||= {}
+  end
+end

--- a/spec/domain/streams/messages/multipart_message_spec.rb
+++ b/spec/domain/streams/messages/multipart_message_spec.rb
@@ -35,34 +35,39 @@ RSpec.describe Streams::Messages::MultipartMessage do
           content_id: message.payload['content_id'],
           schema_name: 'guide'
         )
+        base_warehouse_id = "#{message.payload['content_id']}:#{message.payload['locale']}"
         expect(attributes).to eq([
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}",
+            warehouse_item_id: base_warehouse_id,
+            child_sort_order: ["#{base_warehouse_id}:part2", "#{base_warehouse_id}:part3", "#{base_warehouse_id}:part4"],
             document_text: 'Here 1',
             sibling_order: 0,
             title: 'the-title: Part 1',
             base_path: '/base-path'
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part2",
+            warehouse_item_id: "#{base_warehouse_id}:part2",
             document_text: 'be 2',
             title: 'the-title: Part 2',
             sibling_order: 1,
-            base_path: '/base-path/part2'
+            base_path: '/base-path/part2',
+            parent_warehouse_id: base_warehouse_id
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part3",
+            warehouse_item_id: "#{base_warehouse_id}:part3",
             document_text: 'some 3',
             title: 'the-title: Part 3',
             sibling_order: 2,
-            base_path: '/base-path/part3'
+            base_path: '/base-path/part3',
+            parent_warehouse_id: base_warehouse_id
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part4",
+            warehouse_item_id: "#{base_warehouse_id}:part4",
             document_text: 'content 4.',
             title: 'the-title: Part 4',
             sibling_order: 3,
-            base_path: '/base-path/part4'
+            base_path: '/base-path/part4',
+            parent_warehouse_id: base_warehouse_id
           )
         ])
       end
@@ -83,27 +88,31 @@ RSpec.describe Streams::Messages::MultipartMessage do
           schema_name: 'travel_advice',
           document_type: 'travel_advice'
         )
+        base_warehouse_id = "#{message.payload['content_id']}:#{message.payload['locale']}"
         expect(attributes).to eq([
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}",
+            warehouse_item_id: base_warehouse_id,
+            child_sort_order: ["#{base_warehouse_id}:part1", "#{base_warehouse_id}:part2"],
             document_text: 'summary content',
             title: 'the-title: Summary',
             sibling_order: 0,
             base_path: '/base-path'
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part1",
+            warehouse_item_id: "#{base_warehouse_id}:part1",
             document_text: 'Here 1',
             title: 'the-title: Part 1',
             sibling_order: 1,
-            base_path: '/base-path/part1'
+            base_path: '/base-path/part1',
+            parent_warehouse_id: base_warehouse_id
           ),
           common_attributes.merge(
-            warehouse_item_id: "#{message.payload['content_id']}:#{message.payload['locale']}:part2",
+            warehouse_item_id: "#{base_warehouse_id}:part2",
             document_text: 'be 2',
             title: 'the-title: Part 2',
             sibling_order: 2,
-            base_path: '/base-path/part2'
+            base_path: '/base-path/part2',
+            parent_warehouse_id: base_warehouse_id
           )
         ])
       end

--- a/spec/domain/streams/messages/single_item_message_spec.rb
+++ b/spec/domain/streams/messages/single_item_message_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Streams::Messages::SingleItemMessage do
   include_examples 'BaseMessage#historically_political?'
   include_examples 'BaseMessage#withdrawn_notice?'
 
+  let(:instance) { subject.new(message.payload, "routing_key") }
+
   describe '#edition_attributes' do
     let(:message) do
       msg = build(:message, attributes: message_attributes)
@@ -16,8 +18,6 @@ RSpec.describe Streams::Messages::SingleItemMessage do
       msg.payload['withdrawn_notice'] = { "explanation" => 'something' }
       msg
     end
-
-    let(:instance) { subject.new(message.payload, "routing_key") }
 
     it 'returns the attributes' do
       attributes = instance.edition_attributes
@@ -59,6 +59,60 @@ RSpec.describe Streams::Messages::SingleItemMessage do
       attributes = message.edition_attributes
 
       expect(attributes).to include(acronym: nil)
+    end
+  end
+
+  describe "extracts parent/child from links" do
+    let(:message) { build :message }
+    let(:links) do
+      {
+        'children' => [
+          { 'content_id' => 'child-1-id', 'locale' => 'en' },
+          { 'content_id' => 'child-2-id', 'locale' => 'en' },
+        ],
+        'parent' => [{ 'content_id' => 'parent-id', 'locale' => 'en' }]
+      }
+    end
+
+    before do
+      message.payload['links'] = links
+      message.payload['schema_name'] = 'publication'
+      message.payload['document_type'] = 'guidance'
+    end
+
+    context 'when parent and child links exist' do
+      let(:links) do
+        {
+          'children' => [
+            { 'content_id' => 'child-1-id', 'locale' => 'en' },
+            { 'content_id' => 'child-2-id', 'locale' => 'en' },
+          ],
+          'parent' => [{ 'content_id' => 'parent-id', 'locale' => 'en' }]
+        }
+      end
+      it 'extracts a list of child warehouse ids' do
+        expected = [
+          'child-1-id:en',
+          'child-2-id:en'
+        ]
+        expect(instance.edition_attributes[:child_sort_order]).to eq(expected)
+      end
+
+      it 'sets the parent warehouse id under temp key' do
+        expect(instance.edition_attributes[:parent_warehouse_id]).to eq('parent-id:en')
+      end
+    end
+
+    context 'when link keys are missing' do
+      let(:links) { {} }
+
+      it 'returns null for parent' do
+        expect(instance.edition_attributes[:parent_warehouse_id]).to be_nil
+      end
+
+      it 'returns an empty array for child_sort_order' do
+        expect(instance.edition_attributes[:child_sort_order]).to eq([])
+      end
     end
   end
 end

--- a/spec/integration/streams/multiple/grow_dimension_spec.rb
+++ b/spec/integration/streams/multiple/grow_dimension_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
 
     subject.process(message)
 
-    expect(Dimensions::Edition.count).to eq(5)
+    expect(Dimensions::Edition.count).to eq(6)
     expect(Dimensions::Edition.live.count).to eq(5)
   end
 
@@ -113,7 +113,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
 
     subject.process(message)
 
-    expect(Dimensions::Edition.count).to eq(4)
+    expect(Dimensions::Edition.count).to eq(5)
     expect(Dimensions::Edition.live.count).to eq(3)
   end
 
@@ -126,7 +126,7 @@ RSpec.describe "Process sub-pages for multipart content types" do
 
     subject.process(message)
 
-    expect(Dimensions::Edition.count).to eq(5)
+    expect(Dimensions::Edition.count).to eq(6)
     expect(Dimensions::Edition.live.count).to eq(4)
   end
 

--- a/spec/integration/streams/multiple/parent_child_spec.rb
+++ b/spec/integration/streams/multiple/parent_child_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'multi-part parent/child relationships' do
 
   it 'resets the parent of existing unchanged items' do
     subject.process(message)
-    message.payload['details']['parts'][0][:title] = 'New title'
+    message.payload['details']['parts'][0]['title'] = 'New title'
     message.payload["payload_version"] = message.payload["payload_version"] + 1
     subject.process(message)
     parent = Dimensions::Edition.find_latest("#{content_id}:fr")
@@ -39,7 +39,7 @@ RSpec.describe 'multi-part parent/child relationships' do
   it 'does not reset the parent of old items' do
     old_edition = create :edition, content_id: content_id, locale: 'fr', warehouse_item_id: "#{content_id}:fr:part5"
     subject.process(message)
-    message.payload['details']['parts'][0][:title] = 'New title'
+    message.payload['details']['parts'][0]['title'] = 'New title'
     parent = Dimensions::Edition.find_latest("#{content_id}:fr")
     expect(old_edition.reload.parent).not_to eq(parent)
   end

--- a/spec/integration/streams/parent_child/links_processor_spec.rb
+++ b/spec/integration/streams/parent_child/links_processor_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Streams::ParentChild::LinksProcessor do
+  let!(:parent) { create :edition, child_sort_order: ['child-1:en', 'child-2:en'], warehouse_item_id: 'parent:en' }
+  let!(:child_2) { create :edition, warehouse_item_id: 'child-2:en' }
+  let!(:child_1) { create :edition, warehouse_item_id: 'child-1:en' }
+
+  subject { described_class }
+
+  context 'when the edition has children' do
+    it 'looks up the children and applies the sort order' do
+      subject.update_parent_and_sort_siblings(parent, nil)
+
+      expected = [
+        ['child-1:en', 1],
+        ['child-2:en', 2]
+      ]
+      expect(parent.children.order(:sibling_order).pluck(:warehouse_item_id, :sibling_order)).to eq(expected)
+    end
+  end
+
+  context 'when the edition has a parent' do
+    it 'looks up the parent and applies the sort order' do
+      subject.update_parent_and_sort_siblings(child_1, 'parent:en')
+
+      expected = [
+        ['child-1:en', 1],
+        ['child-2:en', 2]
+      ]
+      expect(parent.children.order(:sibling_order).pluck(:warehouse_item_id, :sibling_order)).to eq(expected)
+    end
+  end
+end

--- a/spec/integration/streams/single/html_publication_parents_spec.rb
+++ b/spec/integration/streams/single/html_publication_parents_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe 'setting parents for html_publications' do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
+  let(:parent_message) do
+    build :message,
+          base_path: '/parent',
+          schema_name: 'publication',
+          attributes: {
+            'document_type' => 'guidance'
+          }
+  end
+
+  let(:attachment_1_message) do
+    build :message,
+          base_path: '/parent/child/1',
+          schema_name: 'html_publication',
+          attributes: { 'document_type' => 'html_publication' }
+  end
+
+  let(:attachment_2_message) do
+    build :message,
+          base_path: '/parent/child/2',
+          schema_name: 'html_publication',
+          attributes: { 'document_type' => 'html_publication' }
+  end
+  let(:links_for_parent) do
+    {
+      'children' =>  [attachment_1_message, attachment_2_message].map do |message|
+        { 'content_id' => message.payload['content_id'], 'locale' => message.payload['locale'] }
+      end
+    }
+  end
+  let(:links_for_child) do
+    { 'parent' => [{
+      'content_id' => parent_message.payload['content_id'],
+      'locale' => parent_message.payload['locale']
+    }] }
+  end
+  subject { Streams::Consumer.new }
+
+  before do
+    parent_message.payload['links'] = links_for_parent
+    attachment_1_message.payload['links'] = links_for_child
+    attachment_2_message.payload['links'] = links_for_child
+  end
+
+  context 'when the parent arrives first' do
+    before do
+      subject.process(parent_message)
+      subject.process(attachment_2_message)
+      subject.process(attachment_1_message)
+    end
+
+    it 'sets the parents correctly' do
+      parent_warehouse_id = "#{parent_message.payload['content_id']}:#{parent_message.payload['locale']}"
+      parent = Dimensions::Edition.where(warehouse_item_id: parent_warehouse_id).first
+      expected = [
+        ["#{attachment_1_message.payload['content_id']}:#{attachment_1_message.payload['locale']}", 1],
+        ["#{attachment_2_message.payload['content_id']}:#{attachment_2_message.payload['locale']}", 2]
+      ]
+      expect(parent.children.order(:sibling_order).pluck(:warehouse_item_id, :sibling_order)).to eq(expected)
+    end
+  end
+
+  context 'when the child messages arrive first' do
+    before do
+      subject.process(attachment_2_message)
+      subject.process(attachment_1_message)
+      subject.process(parent_message)
+    end
+
+    it 'sets the parents correctly' do
+      parent_warehouse_id = "#{parent_message.payload['content_id']}:#{parent_message.payload['locale']}"
+      parent = Dimensions::Edition.where(warehouse_item_id: parent_warehouse_id).first
+      expected = [
+        ["#{attachment_1_message.payload['content_id']}:#{attachment_1_message.payload['locale']}", 1],
+        ["#{attachment_2_message.payload['content_id']}:#{attachment_2_message.payload['locale']}", 2]
+      ]
+      expect(parent.children.order(:sibling_order).pluck(:warehouse_item_id, :sibling_order)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
# What 
Process parent/child relationships for `html_publications`

Uses links> parent and links > children to populate parent/child relationships
between publications and html attachments.

Also includes a fix for multi-part documents (guides, travel advice) which was
not working as was. Now refactored to use the same code as `html_publications`.

# Why

We want to display these relationships/related data in `content-data`

Trello: https://trello.com/c/cBmiTJjc/1497-5-add-streams-processing-and-rake-task-to-populate-parent-child-relationships

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
