### PR TITLE
Parent child relationships for manuals

### DIFF
--- a/app/domain/streams/parent_child/base_parser.rb
+++ b/app/domain/streams/parent_child/base_parser.rb
@@ -1,0 +1,5 @@
+class Streams::ParentChild::BaseParser
+  def self.to_warehouse_id(content_id, locale)
+    "#{content_id}:#{locale}"
+  end
+end

--- a/app/domain/streams/parent_child/manual_section_manual_parser.rb
+++ b/app/domain/streams/parent_child/manual_section_manual_parser.rb
@@ -1,0 +1,14 @@
+class Streams::ParentChild::ManualSectionManualParser < Streams::ParentChild::BaseParser
+  DOCUMENT_TYPES = %w[manual_section].freeze
+
+  def self.get_parent_id(payload)
+    manuals = payload.dig('links', 'manual')
+    return nil if manuals.blank?
+
+    to_warehouse_id(manuals.first['content_id'], manuals.first['locale'])
+  end
+
+  def self.get_children_ids(_)
+    []
+  end
+end

--- a/app/domain/streams/parent_child/manual_sections_parser.rb
+++ b/app/domain/streams/parent_child/manual_sections_parser.rb
@@ -5,4 +5,8 @@ class Streams::ParentChild::ManualSectionsParser < Streams::ParentChild::BasePar
     sections = payload.dig('links', 'sections') || []
     sections.map { |h| to_warehouse_id(h['content_id'], h['locale']) }
   end
+
+  def self.get_parent_id(_)
+    nil
+  end
 end

--- a/app/domain/streams/parent_child/manual_sections_parser.rb
+++ b/app/domain/streams/parent_child/manual_sections_parser.rb
@@ -1,0 +1,8 @@
+class Streams::ParentChild::ManualSectionsParser < Streams::ParentChild::BaseParser
+  DOCUMENT_TYPES = %w[manual].freeze
+
+  def self.get_children_ids(payload)
+    sections = payload.dig('links', 'sections') || []
+    sections.map { |h| to_warehouse_id(h['content_id'], h['locale']) }
+  end
+end

--- a/app/domain/streams/parent_child/parent_child_links_parser.rb
+++ b/app/domain/streams/parent_child/parent_child_links_parser.rb
@@ -1,4 +1,4 @@
-class Streams::ParentChild::ParentChildLinksParser
+class Streams::ParentChild::ParentChildLinksParser < Streams::ParentChild::BaseParser
   DOCUMENT_TYPES = %w[
       guidance
       form
@@ -34,9 +34,5 @@ class Streams::ParentChild::ParentChildLinksParser
     return nil if parent_array.blank?
 
     to_warehouse_id(parent_array.first['content_id'], parent_array.first['locale'])
-  end
-
-  def self.to_warehouse_id(content_id, locale)
-    "#{content_id}:#{locale}"
   end
 end

--- a/app/domain/streams/parent_child/parser.rb
+++ b/app/domain/streams/parent_child/parser.rb
@@ -1,6 +1,8 @@
 class Streams::ParentChild::Parser
   PARSERS = [
-    ::Streams::ParentChild::ParentChildLinksParser
+    ::Streams::ParentChild::ParentChildLinksParser,
+    ::Streams::ParentChild::ManualSectionManualParser,
+    ::Streams::ParentChild::ManualSectionsParser
   ].freeze
 
   def get_parent_id(payload)
@@ -19,10 +21,6 @@ class Streams::ParentChild::Parser
 
   def initialize
     register_parsers
-  end
-
-  def create_parser(document_type)
-    parsers[document_type]
   end
 
 private

--- a/spec/domain/streams/messages/single_item_message_spec.rb
+++ b/spec/domain/streams/messages/single_item_message_spec.rb
@@ -103,16 +103,16 @@ RSpec.describe Streams::Messages::SingleItemMessage do
       end
     end
 
-    context 'when link keys are missing' do
-      let(:links) { {} }
+    it 'extracts a list of child warehouse ids' do
+      expected = [
+        'child-1-id:en',
+        'child-2-id:en'
+      ]
+      expect(instance.edition_attributes[:child_sort_order]).to eq(expected)
+    end
 
-      it 'returns null for parent' do
-        expect(instance.edition_attributes[:parent_warehouse_id]).to be_nil
-      end
-
-      it 'returns an empty array for child_sort_order' do
-        expect(instance.edition_attributes[:child_sort_order]).to eq([])
-      end
+    it 'sets the parent warehouse id under temp key' do
+      expect(instance.edition_attributes[:parent_warehouse_id]).to eq('parent-id:en')
     end
   end
 end

--- a/spec/domain/streams/messages/single_item_message_spec.rb
+++ b/spec/domain/streams/messages/single_item_message_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Streams::Messages::SingleItemMessage do
     end
   end
 
-  describe "extracts parent/child from links" do
+  describe "extracts parent/child from links > parent/children" do
     let(:message) { build :message }
     let(:links) do
       {
@@ -109,6 +109,47 @@ RSpec.describe Streams::Messages::SingleItemMessage do
         'child-2-id:en'
       ]
       expect(instance.edition_attributes[:child_sort_order]).to eq(expected)
+    end
+
+    it 'sets the parent warehouse id under temp key' do
+      expect(instance.edition_attributes[:parent_warehouse_id]).to eq('parent-id:en')
+    end
+  end
+
+  describe "for a manual" do
+    let(:message) { build :message }
+    let(:links) do
+      {
+        'sections' => [
+          { 'content_id' => 'child-1-id', 'locale' => 'en' },
+          { 'content_id' => 'child-2-id', 'locale' => 'en' },
+        ]
+      }
+    end
+
+    before do
+      message.payload['links'] = links
+      message.payload['schema_name'] = 'manual'
+      message.payload['document_type'] = 'manual'
+    end
+
+    it 'extracts a list of child warehouse ids from links > sections' do
+      expected = [
+        'child-1-id:en',
+        'child-2-id:en'
+      ]
+      expect(instance.edition_attributes[:child_sort_order]).to eq(expected)
+    end
+  end
+
+  describe "for a manual section" do
+    let(:message) { build :message }
+    let(:links) { { 'manual' => [{ 'content_id' => 'parent-id', 'locale' => 'en' }] } }
+
+    before do
+      message.payload['links'] = links
+      message.payload['schema_name'] = 'manual_section'
+      message.payload['document_type'] = 'manual_section'
     end
 
     it 'sets the parent warehouse id under temp key' do

--- a/spec/integration/streams/single/manuals_parent_child_spec.rb
+++ b/spec/integration/streams/single/manuals_parent_child_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe 'setting parents for manuals' do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
+  let(:manual_message) do
+    build :message,
+          base_path: '/manual',
+          schema_name: 'manual',
+          attributes: { 'document_type' => 'manual' }
+  end
+
+  let(:section_1_message) do
+    build :message,
+          base_path: '/manual/section-1',
+          schema_name: 'manual_section',
+          attributes: { 'document_type' => 'manual_section' }
+  end
+
+  let(:section_2_message) do
+    build :message,
+          base_path: '/manual/section-2',
+          schema_name: 'manual_section',
+          attributes: { 'document_type' => 'manual_section' }
+  end
+  let(:links_for_parent) do
+    {
+      'sections' => [section_1_message, section_2_message].map do |message|
+        { 'content_id' => message.payload['content_id'], 'locale' => message.payload['locale'] }
+      end
+    }
+  end
+  let(:links_for_child) do
+    { 'manual' => [{
+      'content_id' => manual_message.payload['content_id'],
+      'locale' => manual_message.payload['locale']
+    }] }
+  end
+
+  subject { Streams::Consumer.new }
+
+  before do
+    manual_message.payload['links'] = links_for_parent
+    section_1_message.payload['links'] = links_for_child
+    section_2_message.payload['links'] = links_for_child
+  end
+
+  context 'when the manual arrives first' do
+    before do
+      subject.process(manual_message)
+      subject.process(section_2_message)
+      subject.process(section_1_message)
+    end
+
+    it 'sets the parents correctly' do
+      manual_warehouse_id = "#{manual_message.payload['content_id']}:#{manual_message.payload['locale']}"
+      manual = Dimensions::Edition.where(warehouse_item_id: manual_warehouse_id).first
+      expected = [
+        ["#{section_1_message.payload['content_id']}:#{section_1_message.payload['locale']}", 1],
+        ["#{section_2_message.payload['content_id']}:#{section_2_message.payload['locale']}", 2]
+      ]
+      expect(manual.children.order(:sibling_order).pluck(:warehouse_item_id, :sibling_order)).to eq(expected)
+    end
+  end
+
+  context 'when the sections arrive first' do
+    before do
+      subject.process(section_2_message)
+      subject.process(section_1_message)
+      subject.process(manual_message)
+    end
+
+    it 'sets the parents correctly' do
+      manual_warehouse_id = "#{manual_message.payload['content_id']}:#{manual_message.payload['locale']}"
+      manual = Dimensions::Edition.where(warehouse_item_id: manual_warehouse_id).first
+      expected = [
+        ["#{section_1_message.payload['content_id']}:#{section_1_message.payload['locale']}", 1],
+        ["#{section_2_message.payload['content_id']}:#{section_2_message.payload['locale']}", 2]
+      ]
+      expect(manual.children.order(:sibling_order).pluck(:warehouse_item_id, :sibling_order)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
# Description
Streams processing now populates parent/child relationships for:

manuals : sections from links > sections
manual_section: manual from links > manual

Trello: https://trello.com/c/cBmiTJjc/1497-5-add-streams-processing-and-rake-task-to-populate-parent-child-relationships

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
