### PR TITLE
Return number_of_related_content in single page response

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -77,4 +77,11 @@ class Dimensions::Edition < ApplicationRecord
       parent_content_id: parent_content_id
     }
   end
+
+  def related_content_count
+    child_count = children.count
+    return child_count unless child_count.zero?
+
+    parent.try(:related_content_count) || 0
+  end
 end

--- a/app/views/single_item/show.json.jbuilder
+++ b/app/views/single_item/show.json.jbuilder
@@ -2,6 +2,8 @@ json.metadata do
   json.merge! @live_edition.metadata
 end
 
+json.number_of_related_content @live_edition.related_content_count
+
 json.time_period do
   json.from @from
   json.to @to

--- a/spec/requests/api/single_page_spec.rb
+++ b/spec/requests/api/single_page_spec.rb
@@ -68,6 +68,33 @@ RSpec.describe '/single_page', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    describe 'number of related items' do
+      before do
+        day1 = create :dimensions_date, date: Date.new(2018, 1, 1)
+        (1..4).each do |n|
+          edition = create :edition, base_path: "/child-#{n}", parent: item
+          create :metric, dimensions_edition: edition, dimensions_date: day1
+        end
+      end
+
+      it 'returns the count of children for the parent' do
+        get "/single_page/#{base_path}", params: { from: '2018-01-01', to: '2018-01-31' }
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('number_of_related_content' => 4)
+      end
+
+
+      it 'returns the count of siblings + parent for the child' do
+        get "/single_page/child-1", params: { from: '2018-01-01', to: '2018-01-31' }
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('number_of_related_content' => 4)
+      end
+    end
+
     it 'returns the time period' do
       get "/single_page/#{base_path}", params: { from: '2018-01-01', to: '2018-01-31' }
 


### PR DESCRIPTION
# Description
Return number_of_related_content in single page response

# Why

We need to display information about number of related content items on the page data page so users know how many related items there are to compare against.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
