### PR TITLE
Add param validation to document children endpoint

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -1,4 +1,6 @@
 class Api::DocumentsController < Api::BaseController
+  before_action :validate_params!
+
   def children
     @document_id = params[:document_id]
 
@@ -22,5 +24,15 @@ private
     raise Api::ParentNotFoundError.new("#{params[:document_id]} not found") if parent.nil?
 
     parent
+  end
+
+  def validate_params!
+    unless api_request.valid?
+      error_response(
+        "validation-error",
+        title: "One or more parameters is invalid",
+        invalid_params: api_request.errors.to_hash
+      )
+    end
   end
 end

--- a/spec/requests/api/v1/documents_spec.rb
+++ b/spec/requests/api/v1/documents_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe '/api/v1/documents/:document_id/children', type: :request do
   let(:locale) { 'en' }
   let(:time_period) { 'past-30-days' }
 
-  describe "documents show" do
+  describe "documents children" do
     it "describes a documents with no children" do
       _, parent_response = setup_edition_and_metrics(content_id, locale, 10)
 
@@ -40,6 +40,40 @@ RSpec.describe '/api/v1/documents/:document_id/children', type: :request do
       )
 
       expect(response).to have_http_status(404)
+    end
+  end
+
+  context 'with invalid params' do
+    it 'returns an error for badly formatted dates' do
+      get "/api/v1/documents/#{content_id}:#{locale}/children", params: { time_period: 'invalid' }
+
+      expect(response.status).to eq(400)
+
+      json = JSON.parse(response.body)
+
+      expected_error_response = {
+        'type' => 'https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error',
+        'title' => 'One or more parameters is invalid',
+        'invalid_params' => { 'time_period' => ['this is not a valid time period'] }
+      }
+
+      expect(json).to eq(expected_error_response)
+    end
+
+    it 'returns an error for invalid sort' do
+      get "/api/v1/documents/#{content_id}:#{locale}/children", params: { time_period: 'past-30-days', sort: 'invalid' }
+
+      expect(response.status).to eq(400)
+
+      json = JSON.parse(response.body)
+
+      expected_error_response = {
+        'type' => 'https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error',
+        'title' => 'One or more parameters is invalid',
+        'invalid_params' => { 'sort' => ['this is not a valid sort key'] }
+      }
+
+      expect(json).to eq(expected_error_response)
     end
   end
 end


### PR DESCRIPTION
This adds parameter validation to document children endpoint. Users now receive an error message if parameters are incorrect.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.