### PR TITLE
Add parent document id to single page response

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -52,15 +52,6 @@ class Dimensions::Edition < ApplicationRecord
     dirty
   end
 
-  def parent_content_id
-    return '' unless document_type == 'manual_section'
-
-    _, segment1, segment2 = base_path.split('/')
-    parent_path = "/#{segment1}/#{segment2}"
-    parent = Dimensions::Edition.find_by(base_path: parent_path)
-    parent.content_id
-  end
-
   def metadata
     {
       title: title,
@@ -74,7 +65,6 @@ class Dimensions::Edition < ApplicationRecord
       primary_organisation_title: primary_organisation_title,
       withdrawn: withdrawn,
       historical: historical,
-      parent_content_id: parent_content_id
     }
   end
 end

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -21,6 +21,8 @@ class Dimensions::Edition < ApplicationRecord
       .where.not(base_path: exclude_paths)
   end
 
+  delegate :document_id, to: :parent, prefix: true, allow_nil: true
+
   def self.find_latest(warehouse_item_id)
     query = <<~SQL
       SELECT a.*
@@ -69,6 +71,7 @@ class Dimensions::Edition < ApplicationRecord
       primary_organisation_title: primary_organisation_title,
       withdrawn: withdrawn,
       historical: historical,
+      parent_document_id: parent_document_id,
     }
   end
 end

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -52,6 +52,10 @@ class Dimensions::Edition < ApplicationRecord
     dirty
   end
 
+  def document_id
+    "#{content_id}:#{locale}"
+  end
+
   def metadata
     {
       title: title,

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -204,6 +204,13 @@ RSpec.describe Dimensions::Edition, type: :model do
     end
   end
 
+  describe 'document_id' do
+    it 'returns a fomatted document_id' do
+      edition = create :edition, content_id: '1234', locale: 'en'
+      expect(edition.document_id).to eq('1234:en')
+    end
+  end
+
   describe 'Unique constraint on `warehouse_item_id` and `live`' do
     it 'prevent duplicating `warehouse_item_id` for live items' do
       create :edition, warehouse_item_id: 'value', live: true

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -172,6 +172,7 @@ RSpec.describe Dimensions::Edition, type: :model do
         primary_organisation_title: 'The ministry',
         withdrawn: false,
         historical: false,
+        parent_document_id: nil,
       )
     end
   end
@@ -208,6 +209,21 @@ RSpec.describe Dimensions::Edition, type: :model do
     it 'returns a fomatted document_id' do
       edition = create :edition, content_id: '1234', locale: 'en'
       expect(edition.document_id).to eq('1234:en')
+    end
+  end
+
+  describe 'parent_document_id' do
+    it 'returns a fomatted document_id for parent' do
+      parent = create :edition, content_id: '1234', locale: 'en'
+      child = create :edition, parent: parent
+
+      expect(child.parent_document_id).to eq('1234:en')
+    end
+
+    it 'returns a nil when there is no parent' do
+      parent = create :edition, content_id: '1234', locale: 'en'
+
+      expect(parent.parent_document_id).to eq(nil)
     end
   end
 

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -172,7 +172,6 @@ RSpec.describe Dimensions::Edition, type: :model do
         primary_organisation_title: 'The ministry',
         withdrawn: false,
         historical: false,
-        parent_content_id: ''
       )
     end
   end
@@ -202,15 +201,6 @@ RSpec.describe Dimensions::Edition, type: :model do
       it 'persists and retrieves child_sort_order' do
         expect(parent.reload.child_sort_order).to eq(child_sort_order)
       end
-    end
-  end
-
-  describe '#parent_content_id' do
-    it 'returns content_id of parent manual for a manual_section' do
-      create :edition, content_id: 'the-parent', base_path: '/prefix-path/the-parent-path', document_type: 'manual'
-      child = create :edition, base_path: '/prefix-path/the-parent-path/child-path', document_type: 'manual_section'
-
-      expect(child.parent_content_id).to eq('the-parent')
     end
   end
 

--- a/spec/requests/api/single_page_spec.rb
+++ b/spec/requests/api/single_page_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe '/single_page', type: :request do
           "public_updated_at" => '2018-07-17T10:35:57.000Z',
           "primary_organisation_title" => 'The ministry',
           "withdrawn" => false,
-          "historical" => false
+          "historical" => false,
+          "parent_document_id" => nil
         }
       }
       expect(body['metadata']).to include(expected['metadata'])


### PR DESCRIPTION
This add the parent_document_id attribute to the edition metadata for the single page response. This is needed by the frontend to provide links to the comparison table page for related content.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.