### PR TITLE
Add rake task to re-process editions

### DIFF
--- a/app/domain/streams/handlers/base_handler.rb
+++ b/app/domain/streams/handlers/base_handler.rb
@@ -20,4 +20,14 @@ private
     Streams::ParentChild::LinksProcessor.update_parent_and_sort_siblings(new_edition, parent_warehouse_id)
     new_edition
   end
+
+  def update_existing_edition(attributes, existing_edition)
+    parent_warehouse_id = attributes[:parent_warehouse_id]
+    attributes = attributes.except(:parent_warehouse_id)
+
+    existing_edition.update(attributes)
+
+    Streams::ParentChild::LinksProcessor
+      .update_parent_and_sort_siblings(existing_edition, parent_warehouse_id)
+  end
 end

--- a/app/domain/streams/handlers/multipart_handler.rb
+++ b/app/domain/streams/handlers/multipart_handler.rb
@@ -15,6 +15,12 @@ class Streams::Handlers::MultipartHandler < Streams::Handlers::BaseHandler
     update_editions(attr_list.map(&method(:find_old_edition)))
   end
 
+  def reprocess
+    attr_list.map(&method(:find_old_edition)).each do |h|
+      update_existing_edition(h[:attrs], h[:old_edition])
+    end
+  end
+
 private
 
   def find_old_edition(hash)

--- a/app/domain/streams/handlers/single_item_handler.rb
+++ b/app/domain/streams/handlers/single_item_handler.rb
@@ -18,6 +18,11 @@ class Streams::Handlers::SingleItemHandler < Streams::Handlers::BaseHandler
     update_editions [attrs: attrs, old_edition: find_old_edition(attrs[:warehouse_item_id], attrs[:locale])]
   end
 
+  def reprocess
+    existing_edition = find_old_edition(attrs[:warehouse_item_id], attrs[:locale])
+    update_existing_edition(attrs, existing_edition)
+  end
+
 private
 
   def find_old_edition(warehouse_item_id, locale)

--- a/spec/tasks/editions_spec.rb
+++ b/spec/tasks/editions_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe 'rake editions:*', type: task do
+  describe 'update_existing' do
+    it 'updates edition when payload changes' do
+      payload = build(:message).payload
+      Streams::MessageProcessorJob.perform_now(payload, 'something.major')
+
+      edition = Dimensions::Edition.first
+      edition.publishing_api_event.payload['base_path'] = 'New'
+      edition.publishing_api_event.save!
+
+      Rake::Task['editions:update_existing'].invoke
+
+      edition.reload
+      expect(edition.base_path).to eq('New')
+    end
+
+    it 'updates edition relationship information for multipart' do
+      payload = build(:message, :with_parts).payload
+      Streams::MessageProcessorJob.perform_now(payload, 'something.major')
+
+      old_editions = Dimensions::Edition.all.to_a
+
+      Dimensions::Edition.all.each do |edition|
+        edition.parent = nil
+        edition.sibling_order = nil
+        edition.child_sort_order = nil
+        edition.save!
+      end
+
+      Rake::Task['editions:update_existing'].invoke
+
+      expect(Dimensions::Edition.all).to match_array(old_editions)
+    end
+
+    it 'updates edition relationship information for publication edition' do
+      parent = build(
+        :message,
+        schema_name: 'publication',
+        document_type: 'guidance'
+      ).payload
+
+      child = build(
+        :message,
+        schema_name: 'publication',
+        document_type: 'guidance',
+        base_path: '/child'
+      ).payload
+
+      parent['links']['children'] = [
+        { 'content_id' => child['content_id'], 'locale' => child['locale'] }
+      ]
+
+      child['links']['parent'] = [
+        { 'content_id' => parent['content_id'], 'locale' => parent['locale'] }
+      ]
+
+      Streams::MessageProcessorJob.perform_now(parent, 'something.major')
+      Streams::MessageProcessorJob.perform_now(child, 'something.major')
+
+      old_editions = Dimensions::Edition.all.to_a
+
+      Dimensions::Edition.all.each do |edition|
+        edition.parent = nil
+        edition.sibling_order = nil
+        edition.child_sort_order = nil
+        edition.save!
+      end
+
+      Rake::Task['editions:update_existing'].invoke
+
+      expect(Dimensions::Edition.all).to match_array(old_editions)
+    end
+  end
+end


### PR DESCRIPTION
This rake task "re-proccesses" editions by using the streams processor to generate the edition attributes and update the existing edition in the database. 

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
