### PR TITLE
Update repo to reference the content data api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Content Performance Manager
+# Content Data API
 
 A data warehouse that stores content and content metrics, to help content owners measure and improve content on GOV.UK.
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -61,13 +61,13 @@ private
     # Type is an arbitrary URI identifying the error type
     # https://tools.ietf.org/html/rfc7807#section-3.1 recommends using
     # human-readable documentation for this, so point to our API docs.
-    error_hash[:type] = "https://content-performance-api.publishing.service.gov.uk/errors.html##{type}"
+    error_hash[:type] = "https://content-data-api.publishing.service.gov.uk/errors.html##{type}"
     render json: error_hash, status: :bad_request, content_type: "application/problem+json"
   end
 
   def not_found_response
     response_hash = {
-      type: "https://content-performance-api.publishing.service.gov.uk/errors.html#base-path-not-found",
+      type: "https://content-data-api.publishing.service.gov.uk/errors.html#base-path-not-found",
       title: 'The base path you are looking for cannot be found',
       invalid_params: %w[base_path]
     }

--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -33,7 +33,7 @@ When the API is live, we will follow the [GDS API technical and data standards](
 - provide notices for deprecated endpoints
 
 This is a middleman powered microsite for the API documentation. It
-it is hosted by Github Pages and will eventually be available at https://content-performance-api.publishing.service.gov.uk.
+it is hosted by Github Pages and will eventually be available at https://content-data-api.publishing.service.gov.uk.
 
 This documentation is built from source files in this repository and an
 [OpenAPI specification file](https://github.com/OAI/OpenAPI-Specification), which is used to generate the reference section.

--- a/doc/api/config/tech-docs.yml
+++ b/doc/api/config/tech-docs.yml
@@ -1,11 +1,11 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: https://content-performance-api.publishing.service.gov.uk
+host: https://content-data-api.publishing.service.gov.uk
 api_base_url: https://content-data-api.publishing.service.gov.uk
 api_path: ../../openapi.yaml
 
 # Header-related options
 show_govuk_logo: true
-service_name: Content Performance API
+service_name: Content Data API
 service_link: /
 phase: Alpha
 

--- a/doc/api/source/errors.html.md.erb
+++ b/doc/api/source/errors.html.md.erb
@@ -18,7 +18,7 @@ The base path supplied with the request does not match a known content item. Che
 
 ## Support
 
-If you experience any issues or have questions regarding GOV.UK Content Performance API
+If you experience any issues or have questions regarding GOV.UK Content Data API
 please:
 
 - **if you are a government department:** Raise a ticket with [GOV.UK Support][]
@@ -36,5 +36,5 @@ please:
 [contact the team]: http://dev.gov.uk:4567/#Support
 [GOV.UK Support]: http://dev.gov.uk:4567/#Support
 [Zendesk]: https://www.zendesk.co.uk/
-[GOV.UK Content Performance API]: https://content-performance-api.publishing.service.gov.uk/#gov-uk-content-performance-api
-[reference documentation]: https://content-performance-api.publishing.service.gov.uk/reference.html#gov-uk-content-performance-api-v1-0-0
+[GOV.UK Content Data API]: https://content-data-api.publishing.service.gov.uk/#gov-uk-content-data-api
+[reference documentation]: https://content-data-api.publishing.service.gov.uk/reference.html#gov-uk-content-data-api-v1-0-0

--- a/doc/api/source/index.html.md.erb
+++ b/doc/api/source/index.html.md.erb
@@ -2,7 +2,7 @@
 title: About
 ---
 
-# GOV.UK Content Performance API
+# GOV.UK Content Data API
 
 <div class="phase-tag">
   <p>
@@ -30,7 +30,7 @@ Your application should handle this exception by retrying the request at a later
 
 ## Version
 
-GOV.UK Content Performance API is currently in alpha and is likely to change between versions.
+GOV.UK Content Data API is currently in alpha and is likely to change between versions.
 
 You may use the API and build applications that use it, but live services should not currently rely on the API or the data it provides.
 
@@ -38,7 +38,7 @@ You may use the API and build applications that use it, but live services should
 
 ### Register an API key
 
-Using GOV.UK Content Performance API currently requires [authentication][] using an OAuth2 bearer token.
+Using GOV.UK Content Data API currently requires [authentication][] using an OAuth2 bearer token.
 
 #### GOV.UK users:
 
@@ -46,7 +46,7 @@ Using GOV.UK Content Performance API currently requires [authentication][] using
 2. Click `API Users`.
 3. Click `Create API user button`.
 4. Create the API user.
-5. Click `Add application token` and select `Content Performance Manager` from the list.
+5. Click `Add application token` and select `Content Data Manager` from the list.
 6. Copy the bearer token.
 
 #### GDS users:
@@ -55,12 +55,12 @@ Contact us through #govuk-developers on [GOV.UK Slack][].
 
 #### Government users:
 
-Contact the GOV.UK Content Performance API team through [Zendesk][].
+Contact the GOV.UK Content Data API team through [Zendesk][].
 
 ### Query the API
 
 To query the API, you need to pass the base path (the part after 'www.gov.uk')
-to the content performance API for the piece of content you are interested in.
+to the content data API for the piece of content you are interested in.
 
 For example, for https://www.gov.uk/vat-rates, the base_path will be "/vat-rates"
 
@@ -140,17 +140,17 @@ You can test your integration in the live environment. There is no sandbox envir
 
 ### Reporting vulnerabilities
 
-If you believe there is a security issue with GOV.UK Content Performance API, please [contact us immediately](#support).
+If you believe there is a security issue with GOV.UK Content Data API, please [contact us immediately](#support).
 
 Please don’t disclose the suspected breach publicly until it has been fixed.
 
 ## Security guidelines
 
-[GOV.UK Content Performance API][] follows [government HTTPS security guidelines][] for external facing services and uses HTTPS to provide secure connections.
+[GOV.UK Content Data API][] follows [government HTTPS security guidelines][] for external facing services and uses HTTPS to provide secure connections.
 
 ## Support
 
-If you experience any issues or have questions regarding GOV.UK Content Performance API
+If you experience any issues or have questions regarding GOV.UK Content Data API
 please:
 
 - **if you are a government department:** Raise a ticket with [GOV.UK Support][]
@@ -168,5 +168,5 @@ please:
 [contact the team]: http://dev.gov.uk:4567/#Support
 [GOV.UK Support]: http://dev.gov.uk:4567/#Support
 [Zendesk]: https://www.zendesk.co.uk/
-[GOV.UK Content Performance API]: https://content-performance-api.publishing.service.gov.uk/#gov-uk-content-performance-api
-[reference documentation]: https://content-performance-api.publishing.service.gov.uk/reference.html#gov-uk-content-performance-api-v1-0-0
+[GOV.UK Content Data API]: https://content-data-api.publishing.service.gov.uk/#gov-uk-content-data-api
+[reference documentation]: https://content-data-api.publishing.service.gov.uk/reference.html#gov-uk-content-data-api-v1-0-0

--- a/doc/how_to_handle_errors.md
+++ b/doc/how_to_handle_errors.md
@@ -6,7 +6,7 @@ The main idea is to have only actionable errors in Sentry because otherwise, the
 
 ## If you are a new developer to the team
 
-1. Subscribe to the Sentry team: #govuk-data-informed-team, which will enable notifications for Content Data Admin and Content Performance Manager.
+1. Subscribe to the Sentry team: #govuk-data-informed-team, which will enable notifications for Content Data Admin and Content Data API.
                                  
 ## If you find an Error in Sentry (Production)
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  title: GOV.UK Content Performance API
+  title: GOV.UK Content Data API
   description: |
-    GOV.UK Content Performance API provides metrics about GOV.UK content.
+    GOV.UK Content Data API provides metrics about GOV.UK content.
 
     This API accepts HTTP requests and responds with
     [JSON](https://en.wikipedia.org/wiki/JSON).
@@ -316,7 +316,7 @@ components:
             - can't be blank
             - Dates should use the format YYYY-MM-DD
         type: >-
-          https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error
+          https://content-data-api.publishing.service.gov.uk/errors.html#validation-error
     MetricsExample:
       summary: An list of available metrics.
       value:

--- a/spec/requests/api/single_page_spec.rb
+++ b/spec/requests/api/single_page_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe '/single_page', type: :request do
             "Dates should use the format YYYY-MM-DD"
           ]
         },
-        'type' => 'https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error'
+        'type' => 'https://content-data-api.publishing.service.gov.uk/errors.html#validation-error'
       }
       expect(body).to eq(expected)
       expect(response).to have_http_status(400)
@@ -251,7 +251,7 @@ RSpec.describe '/single_page', type: :request do
             "Dates should use the format YYYY-MM-DD"
           ]
         },
-        'type' => 'https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error'
+        'type' => 'https://content-data-api.publishing.service.gov.uk/errors.html#validation-error'
       }
       expect(body).to eq(expected)
       expect(response).to have_http_status(400)
@@ -276,7 +276,7 @@ RSpec.describe '/single_page', type: :request do
             "Dates should use the format YYYY-MM-DD"
           ]
         },
-        'type' => 'https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error'
+        'type' => 'https://content-data-api.publishing.service.gov.uk/errors.html#validation-error'
       }
       expect(body).to eq(expected)
       expect(response).to have_http_status(400)

--- a/spec/requests/api/v1/content_spec.rb
+++ b/spec/requests/api/v1/content_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe '/content' do
       json = JSON.parse(response.body)
 
       expected_error_response = {
-        'type' => 'https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error',
+        'type' => 'https://content-data-api.publishing.service.gov.uk/errors.html#validation-error',
         'title' => 'One or more parameters is invalid',
         'invalid_params' => { 'date_range' => ['this is not a valid date range'] }
       }
@@ -415,7 +415,7 @@ RSpec.describe '/content' do
       json = JSON.parse(response.body)
 
       expected_error_response = {
-        'type' => 'https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error',
+        'type' => 'https://content-data-api.publishing.service.gov.uk/errors.html#validation-error',
         'title' => 'One or more parameters is invalid',
         'invalid_params' => { 'organisation_id' => ['this is not a valid organisation id'] }
       }

--- a/spec/requests/api/v1/documents_spec.rb
+++ b/spec/requests/api/v1/documents_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe '/api/v1/documents/:document_id/children', type: :request do
       json = JSON.parse(response.body)
 
       expected_error_response = {
-        'type' => 'https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error',
+        'type' => 'https://content-data-api.publishing.service.gov.uk/errors.html#validation-error',
         'title' => 'One or more parameters is invalid',
         'invalid_params' => { 'time_period' => ['this is not a valid time period'] }
       }
@@ -68,7 +68,7 @@ RSpec.describe '/api/v1/documents/:document_id/children', type: :request do
       json = JSON.parse(response.body)
 
       expected_error_response = {
-        'type' => 'https://content-performance-api.publishing.service.gov.uk/errors.html#validation-error',
+        'type' => 'https://content-data-api.publishing.service.gov.uk/errors.html#validation-error',
         'title' => 'One or more parameters is invalid',
         'invalid_params' => { 'sort' => ['this is not a valid sort key'] }
       }


### PR DESCRIPTION
This is to replace the old name of content performance manager to the new name of content data api.

Trello: https://trello.com/c/ofrYuLSl