### PR TITLE
Fix bug with update existing editions rake task

### DIFF
--- a/app/domain/streams/handlers/multipart_handler.rb
+++ b/app/domain/streams/handlers/multipart_handler.rb
@@ -17,7 +17,7 @@ class Streams::Handlers::MultipartHandler < Streams::Handlers::BaseHandler
 
   def reprocess
     attr_list.map(&method(:find_old_edition)).each do |h|
-      update_existing_edition(h[:attrs], h[:old_edition])
+      update_existing_edition(h[:attrs].except(:live), h[:old_edition])
     end
   end
 

--- a/app/domain/streams/handlers/single_item_handler.rb
+++ b/app/domain/streams/handlers/single_item_handler.rb
@@ -20,7 +20,7 @@ class Streams::Handlers::SingleItemHandler < Streams::Handlers::BaseHandler
 
   def reprocess
     existing_edition = find_old_edition(attrs[:warehouse_item_id], attrs[:locale])
-    update_existing_edition(attrs, existing_edition)
+    update_existing_edition(attrs.except(:live), existing_edition)
   end
 
 private

--- a/spec/tasks/editions_spec.rb
+++ b/spec/tasks/editions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'rake editions:*', type: task do
 
       Rake::Task['editions:update_existing'].invoke
 
-      expect(Dimensions::Edition.all).to match_array(old_editions)
+      expect(Dimensions::Edition.live.all).to match_array(old_editions)
     end
 
     it 'updates edition relationship information for publication edition' do
@@ -68,7 +68,7 @@ RSpec.describe 'rake editions:*', type: task do
 
       Rake::Task['editions:update_existing'].invoke
 
-      expect(Dimensions::Edition.all).to match_array(old_editions)
+      expect(Dimensions::Edition.live.all).to match_array(old_editions)
     end
   end
 end


### PR DESCRIPTION
There is a bug with update_existing rake task which updates all editions to live = false. This fix prevents updating the live attribute.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
