### PR TITLE
Find parent/child in expanded_links not links

### DIFF
--- a/app/domain/streams/parent_child/manual_section_manual_parser.rb
+++ b/app/domain/streams/parent_child/manual_section_manual_parser.rb
@@ -2,7 +2,7 @@ class Streams::ParentChild::ManualSectionManualParser < Streams::ParentChild::Ba
   DOCUMENT_TYPES = %w[manual_section].freeze
 
   def self.get_parent_id(payload)
-    manuals = payload.dig('links', 'manual')
+    manuals = payload.dig('expanded_links', 'manual')
     return nil if manuals.blank?
 
     to_warehouse_id(manuals.first['content_id'], manuals.first['locale'])

--- a/app/domain/streams/parent_child/manual_sections_parser.rb
+++ b/app/domain/streams/parent_child/manual_sections_parser.rb
@@ -2,7 +2,7 @@ class Streams::ParentChild::ManualSectionsParser < Streams::ParentChild::BasePar
   DOCUMENT_TYPES = %w[manual].freeze
 
   def self.get_children_ids(payload)
-    sections = payload.dig('links', 'sections') || []
+    sections = payload.dig('expanded_links', 'sections') || []
     sections.map { |h| to_warehouse_id(h['content_id'], h['locale']) }
   end
 

--- a/app/domain/streams/parent_child/parent_child_links_parser.rb
+++ b/app/domain/streams/parent_child/parent_child_links_parser.rb
@@ -24,13 +24,13 @@ class Streams::ParentChild::ParentChildLinksParser < Streams::ParentChild::BaseP
     ].freeze
 
   def self.get_children_ids(payload)
-    children = payload.dig('links', 'children') || []
+    children = payload.dig('expanded_links', 'children') || []
 
     children.map { |h| to_warehouse_id(h['content_id'], h['locale']) }
   end
 
   def self.get_parent_id(payload)
-    parent_array = payload.dig('links', 'parent')
+    parent_array = payload.dig('expanded_links', 'parent')
     return nil if parent_array.blank?
 
     to_warehouse_id(parent_array.first['content_id'], parent_array.first['locale'])

--- a/spec/domain/streams/messages/single_item_message_spec.rb
+++ b/spec/domain/streams/messages/single_item_message_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Streams::Messages::SingleItemMessage do
     let(:message) { build :message }
 
     before do
-      message.payload['links'] = links
+      message.payload['expanded_links'] = links
       message.payload['schema_name'] = 'publication'
       message.payload['document_type'] = 'guidance'
     end
@@ -113,7 +113,7 @@ RSpec.describe Streams::Messages::SingleItemMessage do
     let(:message) { build :message }
 
     before do
-      message.payload['links'] = links
+      message.payload['expanded_links'] = links
       message.payload['schema_name'] = 'manual'
       message.payload['document_type'] = 'manual'
     end
@@ -150,7 +150,7 @@ RSpec.describe Streams::Messages::SingleItemMessage do
     let(:message) { build :message }
 
     before do
-      message.payload['links'] = links
+      message.payload['expanded_links'] = links
       message.payload['schema_name'] = 'manual_section'
       message.payload['document_type'] = 'manual_section'
     end

--- a/spec/integration/streams/single/html_publication_parents_spec.rb
+++ b/spec/integration/streams/single/html_publication_parents_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe 'setting parents for html_publications' do
   subject { Streams::Consumer.new }
 
   before do
-    parent_message.payload['links'] = links_for_parent
-    attachment_1_message.payload['links'] = links_for_child
-    attachment_2_message.payload['links'] = links_for_child
+    parent_message.payload['expanded_links'] = links_for_parent
+    attachment_1_message.payload['expanded_links'] = links_for_child
+    attachment_2_message.payload['expanded_links'] = links_for_child
   end
 
   context 'when the parent arrives first' do

--- a/spec/integration/streams/single/manuals_parent_child_spec.rb
+++ b/spec/integration/streams/single/manuals_parent_child_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe 'setting parents for manuals' do
   subject { Streams::Consumer.new }
 
   before do
-    manual_message.payload['links'] = links_for_parent
-    section_1_message.payload['links'] = links_for_child
-    section_2_message.payload['links'] = links_for_child
+    manual_message.payload['expanded_links'] = links_for_parent
+    section_1_message.payload['expanded_links'] = links_for_child
+    section_2_message.payload['expanded_links'] = links_for_child
   end
 
   context 'when the manual arrives first' do


### PR DESCRIPTION
I forgot the payload from publishing API has `expanded_links` not `links` in #1282 and #1283

Corrected here.

