### PR TITLE
Add parent base_path to document children response

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -4,9 +4,9 @@ class Api::DocumentsController < Api::BaseController
   def children
     @document_id = params[:document_id]
 
-    parent = find_parent_edition!
+    @parent = find_parent_edition!
 
-    @documents = Finders::DocumentChildren.call(parent, api_request.to_filter)
+    @documents = Finders::DocumentChildren.call(@parent, api_request.to_filter)
   end
 
 private

--- a/app/views/api/documents/children.json.jbuilder
+++ b/app/views/api/documents/children.json.jbuilder
@@ -1,3 +1,4 @@
+json.parent_base_path @parent.base_path
 json.documents @documents do |document|
   json.base_path document.base_path
   json.title document.title

--- a/spec/requests/api/v1/documents_spec.rb
+++ b/spec/requests/api/v1/documents_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe '/api/v1/documents/:document_id/children', type: :request do
 
   describe "documents children" do
     it "describes a documents with no children" do
-      _, parent_response = setup_edition_and_metrics(content_id, locale, 10)
+      parent, parent_response = setup_edition_and_metrics(content_id, locale, 10)
 
       get "/api/v1/documents/#{content_id}:#{locale}/children?time_period=#{time_period}"
 
       json = JSON.parse(response.body)
 
-      expect(json).to include("documents" => [parent_response])
+      expect(json).to include("parent_base_path" => parent.base_path, "documents" => [parent_response])
     end
 
     it "describes a documents with children" do
@@ -26,7 +26,7 @@ RSpec.describe '/api/v1/documents/:document_id/children', type: :request do
 
       json = JSON.parse(response.body)
 
-      expect(json).to include("documents" => [parent_response, child1_response, child2_response])
+      expect(json).to include("parent_base_path" => parent.base_path, "documents" => [parent_response, child1_response, child2_response])
     end
 
     it "describes the children documents when parent does not exist" do


### PR DESCRIPTION
This will allow an explicit reference to the parent page in the group of content. Using the base path instead of the content id to distinguish multipart content such as guides where the content
id is the same for each page.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.