### PR TITLE
Fix multipart parent update

### DIFF
--- a/app/domain/streams/parent_child/links_processor.rb
+++ b/app/domain/streams/parent_child/links_processor.rb
@@ -24,7 +24,7 @@ private
   end
 
   def get_parent
-    Dimensions::Edition.where(warehouse_item_id: parent_warehouse_id).first
+    Dimensions::Edition.where(warehouse_item_id: parent_warehouse_id, live: true).first
   end
 
   def update_parent_and_sort(children)

--- a/spec/integration/streams/multiple/parent_child_spec.rb
+++ b/spec/integration/streams/multiple/parent_child_spec.rb
@@ -43,4 +43,78 @@ RSpec.describe 'multi-part parent/child relationships' do
     parent = Dimensions::Edition.find_latest("#{content_id}:fr")
     expect(old_edition.reload.parent).not_to eq(parent)
   end
+
+  it 'populates the relationship information for new content item' do
+    subject.process(message)
+
+    editions = Dimensions::Edition.all.pluck(:warehouse_item_id, :title, :sibling_order, :parent_id, :live)
+    parent_id = Dimensions::Edition.where(title: 'Main Title: Part 1').first.id
+
+    expect(editions).to include(
+      ["#{content_id}:fr", "Main Title: Part 1", 0, nil, true],
+      ["#{content_id}:fr:part2", "Main Title: Part 2", 1, parent_id, true],
+      ["#{content_id}:fr:part3", "Main Title: Part 3", 2, parent_id, true],
+      ["#{content_id}:fr:part4", "Main Title: Part 4", 3, parent_id, true],
+    )
+  end
+
+  it 'populates the relationship information for updating all parts of an existing content item' do
+    subject.process(message)
+    new_message = build(:message, :with_parts, attributes: { 'content_id' => content_id, 'title' => 'New Title', 'locale' => 'fr' })
+    subject.process(new_message)
+
+    editions = Dimensions::Edition.all.pluck(:warehouse_item_id, :title, :sibling_order, :parent_id, :live)
+    new_parent_id = Dimensions::Edition.where(title: 'New Title: Part 1').first.id
+
+    expect(editions).to include(
+      ["#{content_id}:fr", "Main Title: Part 1", 0, nil, false],
+      ["#{content_id}:fr:part2", "Main Title: Part 2", 1, new_parent_id, false],
+      ["#{content_id}:fr:part3", "Main Title: Part 3", 2, new_parent_id, false],
+      ["#{content_id}:fr:part4", "Main Title: Part 4", 3, new_parent_id, false],
+      ["#{content_id}:fr", "New Title: Part 1", 0, nil, true],
+      ["#{content_id}:fr:part2", "New Title: Part 2", 1, new_parent_id, true],
+      ["#{content_id}:fr:part3", "New Title: Part 3", 2, new_parent_id, true],
+      ["#{content_id}:fr:part4", "New Title: Part 4", 3, new_parent_id, true],
+    )
+  end
+
+  it 'populates the relationship information for updating a single child of an existing content item' do
+    subject.process(message)
+
+    new_message = message
+    new_message.payload['details']['parts'][1]['title'] = 'New section'
+    new_message.payload['payload_version'] += 1
+    subject.process(new_message)
+
+    editions = Dimensions::Edition.all.pluck(:warehouse_item_id, :title, :sibling_order, :parent_id, :live)
+    parent_id = Dimensions::Edition.where(title: 'Main Title: Part 1').first.id
+
+    expect(editions).to include(
+      ["#{content_id}:fr", "Main Title: Part 1", 0, nil, true],
+      ["#{content_id}:fr:part2", "Main Title: Part 2", 1, parent_id, false],
+      ["#{content_id}:fr:part3", "Main Title: Part 3", 2, parent_id, true],
+      ["#{content_id}:fr:part4", "Main Title: Part 4", 3, parent_id, true],
+      ["#{content_id}:fr:part2", "Main Title: New section", 1, parent_id, true],
+    )
+  end
+
+  it 'populates the relationship information for updating only the parent of an existing content item' do
+    subject.process(message)
+
+    new_message = message
+    new_message.payload['details']['parts'][0]['title'] = 'New parent'
+    new_message.payload['payload_version'] += 1
+    subject.process(new_message)
+
+    editions = Dimensions::Edition.all.pluck(:warehouse_item_id, :title, :sibling_order, :parent_id, :live)
+    parent_id = Dimensions::Edition.where(title: 'Main Title: New parent').first.id
+
+    expect(editions).to include(
+      ["#{content_id}:fr", "Main Title: Part 1", 0, nil, false],
+      ["#{content_id}:fr:part2", "Main Title: Part 2", 1, parent_id, true],
+      ["#{content_id}:fr:part3", "Main Title: Part 3", 2, parent_id, true],
+      ["#{content_id}:fr:part4", "Main Title: Part 4", 3, parent_id, true],
+      ["#{content_id}:fr", "Main Title: New parent", 0, nil, true],
+    )
+  end
 end


### PR DESCRIPTION
There was an issue the links processor where it updated new children with the incorrect old parent. Added a constraint to the links processor to look up the parent by live editions to ensure the children reference the latest live parent.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
