### PR TITLE
Make etl more resilient

### DIFF
--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -22,7 +22,7 @@ private
   attr_reader :date, :month
 
   def create_month
-    @month = Dimensions::Month.for_date(date)
+    @month = Dimensions::Month.find_existing_or_create(date)
   end
 
   def delete_month

--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -22,7 +22,7 @@ private
   attr_reader :date, :month
 
   def create_month
-    @month = Dimensions::Month.find_or_create(date)
+    @month = Dimensions::Month.for_date(date)
   end
 
   def delete_month

--- a/app/domain/etl/edition/processor.rb
+++ b/app/domain/etl/edition/processor.rb
@@ -4,7 +4,7 @@ class Etl::Edition::Processor
   end
 
   def initialize(old_edition, new_edition, date = Time.zone.today)
-    @dimensions_date = Dimensions::Date.find_or_create(date)
+    @dimensions_date = Dimensions::Date.for_date(date)
     @old_edition = old_edition
     @new_edition = new_edition
   end

--- a/app/domain/etl/edition/processor.rb
+++ b/app/domain/etl/edition/processor.rb
@@ -4,7 +4,7 @@ class Etl::Edition::Processor
   end
 
   def initialize(old_edition, new_edition, date = Time.zone.today)
-    @dimensions_date = Dimensions::Date.for_date(date)
+    @dimensions_date = Dimensions::Date.find_existing_or_create(date)
     @old_edition = old_edition
     @new_edition = new_edition
   end

--- a/app/domain/etl/master/master_processor.rb
+++ b/app/domain/etl/master/master_processor.rb
@@ -14,7 +14,7 @@ class Etl::Master::MasterProcessor
   end
 
   def process
-    raise DuplicateDateError if already_run?
+    delete_existing_metrics if already_run?
 
     processor_failures = 0
     monitor_failures = 0
@@ -62,6 +62,7 @@ private
     date != Date.yesterday
   end
 
-  class DuplicateDateError < StandardError;
+  def delete_existing_metrics
+    Facts::Metric.where(dimensions_date_id: @date).delete_all
   end
 end

--- a/app/domain/etl/master/metrics_processor.rb
+++ b/app/domain/etl/master/metrics_processor.rb
@@ -25,7 +25,7 @@ module Etl
 
       def create_metrics
         log process: :metrics, message: 'about to get the Dimensions::Date'
-        dimensions_date = Dimensions::Date.for_date(date)
+        dimensions_date = Dimensions::Date.find_existing_or_create(date)
         log process: :metrics, message: 'got the Dimensions::Date'
         Dimensions::Edition.live.find_in_batches(batch_size: 50000)
           .with_index do |batch, index|

--- a/app/domain/etl/master/metrics_processor.rb
+++ b/app/domain/etl/master/metrics_processor.rb
@@ -25,7 +25,7 @@ module Etl
 
       def create_metrics
         log process: :metrics, message: 'about to get the Dimensions::Date'
-        dimensions_date = Dimensions::Date.find_or_create(date)
+        dimensions_date = Dimensions::Date.for_date(date)
         log process: :metrics, message: 'got the Dimensions::Date'
         Dimensions::Edition.live.find_in_batches(batch_size: 50000)
           .with_index do |batch, index|

--- a/app/domain/monitor/facts.rb
+++ b/app/domain/monitor/facts.rb
@@ -39,7 +39,7 @@ private
 
   def statsd_for_yesterday_editions!
     path = path_for('daily_editions')
-    count = Facts::Edition.where(dimensions_date: Dimensions::Date.find_or_create(Date.yesterday)).count
+    count = Facts::Edition.where(dimensions_date: Dimensions::Date.for_date(Date.yesterday)).count
 
     GovukStatsd.count(path, count)
   end

--- a/app/domain/monitor/facts.rb
+++ b/app/domain/monitor/facts.rb
@@ -39,7 +39,7 @@ private
 
   def statsd_for_yesterday_editions!
     path = path_for('daily_editions')
-    count = Facts::Edition.where(dimensions_date: Dimensions::Date.for_date(Date.yesterday)).count
+    count = Facts::Edition.where(dimensions_date: Dimensions::Date.find_existing_or_create(Date.yesterday)).count
 
     GovukStatsd.count(path, count)
   end

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -30,12 +30,8 @@ class Dimensions::Date < ApplicationRecord
     date_dimension
   end
 
-  def self.find_or_create(date)
-    begin
-      find_by(date: date) || create_with(date)
-    rescue ActiveRecord::RecordNotUnique
-      find_by(date: date)
-    end
+  def self.for_date(date)
+    find_by(date: date) || create_with(date)
   end
 
   def self.exists?(date)

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -30,7 +30,7 @@ class Dimensions::Date < ApplicationRecord
     date_dimension
   end
 
-  def self.for_date(date)
+  def self.find_existing_or_create(date)
     find_by(date: date) || create_with(date)
   end
 

--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -31,7 +31,11 @@ class Dimensions::Date < ApplicationRecord
   end
 
   def self.find_existing_or_create(date)
-    find_by(date: date) || create_with(date)
+    begin
+      find_by(date: date) || create_with(date)
+    rescue ActiveRecord::RecordNotUnique
+      find_by(date: date)
+    end
   end
 
   def self.exists?(date)

--- a/app/models/dimensions/month.rb
+++ b/app/models/dimensions/month.rb
@@ -8,25 +8,31 @@ class Dimensions::Month < ApplicationRecord
   validates :month_name_abbreviated, presence: true, inclusion: { in: ::Date::ABBR_MONTHNAMES }
 
   def self.current
-    find_or_create(Time.zone.today)
+    for_date(Time.zone.today)
   end
 
-  def self.find_or_create(date)
-    month = build(date)
-    month.save!
-    month
-  rescue ActiveRecord::RecordNotUnique
-    find(month.id)
+  def self.create_with(date)
+    month_dimension = build(date)
+    month_dimension.save!
+    month_dimension
+  end
+
+  def self.for_date(date)
+    find_by(id: format_id(date)) || create_with(date)
   end
 
   def self.build(date)
     new(
-      id: format('%04d-%02d', date.year, date.month),
+      id: format_id(date),
       month_number: date.month,
       month_name: date.strftime('%B'),
       month_name_abbreviated: date.strftime('%b'),
       year: date.year,
       quarter: ((date.month - 1) / 3) + 1,
     )
+  end
+
+  def self.format_id(date)
+    format('%04d-%02d', date.year, date.month)
   end
 end

--- a/app/models/dimensions/month.rb
+++ b/app/models/dimensions/month.rb
@@ -33,6 +33,6 @@ class Dimensions::Month < ApplicationRecord
   end
 
   def self.format_id(date)
-    format('%04d-%02d', date.year, date.month)
+    format(Date::DATE_FORMATS[:month_edition], date.year, date.month)
   end
 end

--- a/app/models/dimensions/month.rb
+++ b/app/models/dimensions/month.rb
@@ -8,7 +8,7 @@ class Dimensions::Month < ApplicationRecord
   validates :month_name_abbreviated, presence: true, inclusion: { in: ::Date::ABBR_MONTHNAMES }
 
   def self.current
-    for_date(Time.zone.today)
+    find_existing_or_create(Time.zone.today)
   end
 
   def self.create_with(date)
@@ -17,7 +17,7 @@ class Dimensions::Month < ApplicationRecord
     month_dimension
   end
 
-  def self.for_date(date)
+  def self.find_existing_or_create(date)
     find_by(id: format_id(date)) || create_with(date)
   end
 

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -16,6 +16,6 @@ class Facts::Metric < ApplicationRecord
   validates :dimensions_date, presence: true
   validates :dimensions_edition, presence: true
 
-  scope :for_yesterday, -> { where(dimensions_date: Dimensions::Date.for_date(Date.yesterday)) }
+  scope :for_yesterday, -> { where(dimensions_date: Dimensions::Date.find_existing_or_create(Date.yesterday)) }
   scope :from_day_before_to, ->(date) { where(dimensions_date: Dimensions::Date.between(date - 1, date)) }
 end

--- a/app/models/facts/metric.rb
+++ b/app/models/facts/metric.rb
@@ -16,6 +16,6 @@ class Facts::Metric < ApplicationRecord
   validates :dimensions_date, presence: true
   validates :dimensions_edition, presence: true
 
-  scope :for_yesterday, -> { where(dimensions_date: Dimensions::Date.find_or_create(Date.yesterday)) }
+  scope :for_yesterday, -> { where(dimensions_date: Dimensions::Date.for_date(Date.yesterday)) }
   scope :from_day_before_to, ->(date) { where(dimensions_date: Dimensions::Date.between(date - 1, date)) }
 end

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,4 @@
 Date::DATE_FORMATS[:short] = "%d/%m/%y"
+
+#2018-12
+Date::DATE_FORMATS[:month_edition] = "%04d-%02d"

--- a/spec/domain/etl/master/metrics_spec.rb
+++ b/spec/domain/etl/master/metrics_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Etl::Master::MetricsProcessor do
 
     expect(Facts::Metric.count).to eq(2)
     expect(Facts::Metric.find_by(dimensions_edition: item)).to have_attributes(
-      dimensions_date: Dimensions::Date.find_or_create(Date.new(2018, 3, 15)),
+      dimensions_date: Dimensions::Date.for_date(Date.new(2018, 3, 15)),
       dimensions_edition: item,
     )
   end

--- a/spec/domain/etl/master/metrics_spec.rb
+++ b/spec/domain/etl/master/metrics_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Etl::Master::MetricsProcessor do
 
     expect(Facts::Metric.count).to eq(2)
     expect(Facts::Metric.find_by(dimensions_edition: item)).to have_attributes(
-      dimensions_date: Dimensions::Date.for_date(Date.new(2018, 3, 15)),
+      dimensions_date: Dimensions::Date.find_existing_or_create(Date.new(2018, 3, 15)),
       dimensions_edition: item,
     )
   end

--- a/spec/factories/dimensions_date.rb
+++ b/spec/factories/dimensions_date.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :dimensions_date, class: Dimensions::Date do
     sequence(:date) { |i| i.days.ago.to_date }
 
-    initialize_with { Dimensions::Date.for_date(date.to_date) }
+    initialize_with { Dimensions::Date.find_existing_or_create(date.to_date) }
   end
 end

--- a/spec/factories/dimensions_date.rb
+++ b/spec/factories/dimensions_date.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :dimensions_date, class: Dimensions::Date do
     sequence(:date) { |i| i.days.ago.to_date }
 
-    initialize_with { Dimensions::Date.find_or_create(date.to_date) }
+    initialize_with { Dimensions::Date.for_date(date.to_date) }
   end
 end

--- a/spec/factories/metrics.rb
+++ b/spec/factories/metrics.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :metric, class: Facts::Metric do
-    dimensions_date { Dimensions::Date.for_date(date.to_date) }
+    dimensions_date { Dimensions::Date.find_existing_or_create(date.to_date) }
     dimensions_edition { edition }
     pviews { 10 }
     upviews { 5 }

--- a/spec/factories/metrics.rb
+++ b/spec/factories/metrics.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :metric, class: Facts::Metric do
-    dimensions_date { Dimensions::Date.find_or_create(date.to_date) }
+    dimensions_date { Dimensions::Date.for_date(date.to_date) }
     dimensions_edition { edition }
     pviews { 10 }
     upviews { 5 }

--- a/spec/factories/monthly_metrics.rb
+++ b/spec/factories/monthly_metrics.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     dimensions_month do
       y, m = *month.split('-').map(&:to_i)
 
-      Dimensions::Month.for_date(Date.new(y, m, 1))
+      Dimensions::Month.find_existing_or_create(Date.new(y, m, 1))
     end
 
     dimensions_edition { edition }

--- a/spec/factories/monthly_metrics.rb
+++ b/spec/factories/monthly_metrics.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     dimensions_month do
       y, m = *month.split('-').map(&:to_i)
 
-      Dimensions::Month.find_or_create(Date.new(y, m, 1))
+      Dimensions::Month.for_date(Date.new(y, m, 1))
     end
 
     dimensions_edition { edition }

--- a/spec/models/dimensions/date_spec.rb
+++ b/spec/models/dimensions/date_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Dimensions::Date, type: :model do
   end
 
 
-  describe '.for_date' do
+  describe '.find_existing_or_create' do
     let(:date) { ::Date.new(2017, 12, 21) }
 
     context 'when a dimension exists for the given date' do
@@ -120,13 +120,13 @@ RSpec.describe Dimensions::Date, type: :model do
         dimensions_date = create(:dimensions_date, date: date)
         dimensions_date.save!
 
-        expect(Dimensions::Date.for_date(date)).to eq(dimensions_date)
+        expect(Dimensions::Date.find_existing_or_create(date)).to eq(dimensions_date)
       end
     end
 
     context 'when a dimension does not exist for the given date' do
       it 'should return the newly created dimension' do
-        dimensions_date = Dimensions::Date.for_date(date)
+        dimensions_date = Dimensions::Date.find_existing_or_create(date)
 
         expect(Dimensions::Date.count).to eq(1)
         expect(dimensions_date.date).to eq(date)
@@ -140,7 +140,7 @@ RSpec.describe Dimensions::Date, type: :model do
           dimensions_date.save
           raise ActiveRecord::RecordNotUnique
         }
-        expect(Dimensions::Date.for_date(date)).to eq(dimensions_date)
+        expect(Dimensions::Date.find_existing_or_create(date)).to eq(dimensions_date)
       end
     end
   end

--- a/spec/models/dimensions/date_spec.rb
+++ b/spec/models/dimensions/date_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Dimensions::Date, type: :model do
   end
 
 
-  describe '.find_or_create' do
+  describe '.for_date' do
     let(:date) { ::Date.new(2017, 12, 21) }
 
     context 'when a dimension exists for the given date' do
@@ -120,13 +120,13 @@ RSpec.describe Dimensions::Date, type: :model do
         dimensions_date = create(:dimensions_date, date: date)
         dimensions_date.save!
 
-        expect(Dimensions::Date.find_or_create(date)).to eq(dimensions_date)
+        expect(Dimensions::Date.for_date(date)).to eq(dimensions_date)
       end
     end
 
     context 'when a dimension does not exist for the given date' do
       it 'should return the newly created dimension' do
-        dimensions_date = Dimensions::Date.find_or_create(date)
+        dimensions_date = Dimensions::Date.for_date(date)
 
         expect(Dimensions::Date.count).to eq(1)
         expect(dimensions_date.date).to eq(date)
@@ -140,7 +140,7 @@ RSpec.describe Dimensions::Date, type: :model do
           dimensions_date.save
           raise ActiveRecord::RecordNotUnique
         }
-        expect(Dimensions::Date.find_or_create(date)).to eq(dimensions_date)
+        expect(Dimensions::Date.for_date(date)).to eq(dimensions_date)
       end
     end
   end

--- a/spec/models/dimensions/month_spec.rb
+++ b/spec/models/dimensions/month_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Dimensions::Month, type: :model do
   it { is_expected.to validate_numericality_of(:quarter).only_integer }
   it { is_expected.to validate_inclusion_of(:quarter).in_range(1..4) }
 
-  describe '.find_or_create' do
+  describe '.for_date' do
     subject { described_class }
 
     context 'when month does exist' do

--- a/spec/models/dimensions/month_spec.rb
+++ b/spec/models/dimensions/month_spec.rb
@@ -25,21 +25,21 @@ RSpec.describe Dimensions::Month, type: :model do
       before { subject.current.save }
 
       it 'returns the month if it exists' do
-        expect(-> { subject.find_or_create(Time.zone.today) }).to change(Dimensions::Month, :count).by(0)
+        expect(-> { subject.for_date(Time.zone.today) }).to change(Dimensions::Month, :count).by(0)
       end
 
       it 'returns the month' do
-        expect(subject.find_or_create(Time.zone.today)).to eq(Dimensions::Month.current)
+        expect(subject.for_date(Time.zone.today)).to eq(Dimensions::Month.current)
       end
     end
 
     context 'when month does not exist' do
       it 'creates the month' do
-        expect(-> { subject.find_or_create(Time.zone.today) }).to change(Dimensions::Month, :count).by(1)
+        expect(-> { subject.for_date(Time.zone.today) }).to change(Dimensions::Month, :count).by(1)
       end
 
       it 'returns the month' do
-        expect(subject.find_or_create(Time.zone.today)).to eq(Dimensions::Month.current)
+        expect(subject.for_date(Time.zone.today)).to eq(Dimensions::Month.current)
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe Dimensions::Month, type: :model do
 
     it 'returns current month' do
       Timecop.freeze(2018, 10, 12) do
-        current_month = Dimensions::Month.find_or_create(Time.zone.today)
+        current_month = Dimensions::Month.for_date(Time.zone.today)
 
         expect(subject.current).to eq(current_month)
       end

--- a/spec/models/dimensions/month_spec.rb
+++ b/spec/models/dimensions/month_spec.rb
@@ -18,28 +18,28 @@ RSpec.describe Dimensions::Month, type: :model do
   it { is_expected.to validate_numericality_of(:quarter).only_integer }
   it { is_expected.to validate_inclusion_of(:quarter).in_range(1..4) }
 
-  describe '.for_date' do
+  describe '.find_existing_or_create' do
     subject { described_class }
 
     context 'when month does exist' do
       before { subject.current.save }
 
       it 'returns the month if it exists' do
-        expect(-> { subject.for_date(Time.zone.today) }).to change(Dimensions::Month, :count).by(0)
+        expect(-> { subject.find_existing_or_create(Time.zone.today) }).to change(Dimensions::Month, :count).by(0)
       end
 
       it 'returns the month' do
-        expect(subject.for_date(Time.zone.today)).to eq(Dimensions::Month.current)
+        expect(subject.find_existing_or_create(Time.zone.today)).to eq(Dimensions::Month.current)
       end
     end
 
     context 'when month does not exist' do
       it 'creates the month' do
-        expect(-> { subject.for_date(Time.zone.today) }).to change(Dimensions::Month, :count).by(1)
+        expect(-> { subject.find_existing_or_create(Time.zone.today) }).to change(Dimensions::Month, :count).by(1)
       end
 
       it 'returns the month' do
-        expect(subject.for_date(Time.zone.today)).to eq(Dimensions::Month.current)
+        expect(subject.find_existing_or_create(Time.zone.today)).to eq(Dimensions::Month.current)
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe Dimensions::Month, type: :model do
 
     it 'returns current month' do
       Timecop.freeze(2018, 10, 12) do
-        current_month = Dimensions::Month.for_date(Time.zone.today)
+        current_month = Dimensions::Month.find_existing_or_create(Time.zone.today)
 
         expect(subject.current).to eq(current_month)
       end


### PR DESCRIPTION
# Description
Attempt to tidy up the Etl:Master process - includes:

* Allow Etl:Master to be re-run without raising an error.
* Rename `find_or_create` to `for_date` for `Dimensions:Date` and `Dimensions::Month`

Trello: https://trello.com/c/TYYrZ08d/653-content-data-api-etl-extract-transform-load
