### PR TITLE
Simplify rerun_master task

### DIFF
--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -1,5 +1,5 @@
 namespace :etl do
-  desc "Run ETL master process"
+  desc "Run ETL master process for yesterday"
   task master: :environment do
     unless Etl::Master::MasterProcessor.process
       abort("Etl::Master::MasterProcessor failed")

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -80,21 +80,17 @@ namespace :etl do
     end
   end
 
-  desc "Delete existing metrics and Run Etl Master process across a range of dates"
+  desc "Run ETL Master process across a range of dates"
   task :rerun_master, %i[from to] => [:environment] do |_t, args|
     from = args[:from].to_date
     to = args[:to].to_date
     date_range = (from..to)
     date_range.each do |date|
-      ActiveRecord::Base.transaction do
-        console_log "Deleting existing metrics for #{date}"
-        Facts::Metric.where(dimensions_date_id: date).delete_all
-        console_log "Running Etl::Master process for #{date}"
-        unless Etl::Master::MasterProcessor.process(date: date)
-          abort("Etl::Master::MasterProcessor failed")
-        end
-        console_log "finished running Etl::Master for #{date}"
+      console_log "Running Etl::Master process for #{date}"
+      unless Etl::Master::MasterProcessor.process(date: date)
+        abort("Etl::Master::MasterProcessor failed")
       end
+      console_log "finished running Etl::Master for #{date}"
     end
 
     extract_month_ends(date_range).each do |date|

--- a/spec/tasks/etl_spec.rb
+++ b/spec/tasks/etl_spec.rb
@@ -96,10 +96,6 @@ RSpec.describe "etl.rake", type: task do
       Rake::Task["etl:rerun_master"].invoke("2018-10-31", "2018-11-02")
     end
 
-    it "deletes the existing metrics" do
-      expect(Facts::Metric.pluck(:dimensions_date_id)).to eq([Date.new(2018, 10, 30), Date.new(2018, 11, 3)])
-    end
-
     it "calls Etl::Master::MasterProcessor.process with each date" do
       [Date.new(2018, 10, 31), Date.new(2018, 11, 1), Date.new(2018, 11, 2)].each do |date|
         expect(processor).to have_received(:process).once.with(date: date)


### PR DESCRIPTION
This simplifies the `rerun_master` task to not remove old metrics first (as this now happens automatically by the master processor) and clarifies the documentation around it.

Previously there was confusion over why we have a `master` and a `rerun_master` command - this should be clearer now as the `rerun_master` command is used to specify a historical date range whereas `master` is used to populate the data for yesterday (it runs automatically each day).

[Trello Card](https://trello.com/c/TXNPUh8l/663-combine-content-data-etl-master-and-etl-rerunmaster-tasks)