### PR TITLE
Ignore paths that are invalid URIs

### DIFF
--- a/app/domain/etl/ga/views_and_navigation_service.rb
+++ b/app/domain/etl/ga/views_and_navigation_service.rb
@@ -39,7 +39,7 @@ private
   end
 
   def long_query_string?(data)
-    data["page_path"].length > PAGE_PATH_LENGTH_LIMIT && !URI.parse(data["page_path"]).query.nil?
+    data["page_path"].length > PAGE_PATH_LENGTH_LIMIT && URI.parse(data["page_path"]).query.present?
   end
 
   def extract_dimensions_and_metrics(row)

--- a/app/domain/etl/ga/views_and_navigation_service.rb
+++ b/app/domain/etl/ga/views_and_navigation_service.rb
@@ -12,7 +12,7 @@ class Etl::GA::ViewsAndNavigationService
       .flat_map(&method(:extract_rows))
       .map(&method(:extract_dimensions_and_metrics))
       .map(&method(:append_data_labels))
-      .reject(&method(:long_query_string?))
+      .reject(&method(:invalid_record?))
       .map { |h| h["date"] = date.strftime("%F"); h }
       .each_slice(batch_size) { |slice| yield slice }
   end
@@ -38,8 +38,10 @@ private
     }
   end
 
-  def long_query_string?(data)
-    data["page_path"].length > PAGE_PATH_LENGTH_LIMIT && URI.parse(data["page_path"]).query.present?
+  def invalid_record?(data)
+    URI.parse(data["page_path"]).query.present? && data["page_path"].length > PAGE_PATH_LENGTH_LIMIT
+  rescue URI::InvalidURIError
+    true
   end
 
   def extract_dimensions_and_metrics(row)


### PR DESCRIPTION
We're seeing a bug where the ETL task can't import a URI because it's not valid.

[Trello Card](https://trello.com/c/uJN5DC8h/1448-3-content-data-url-error-in-etl-task-means-theres-missing-data-for-27-september)