### PR TITLE
Replace govuk-lint with rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 inherit_gem:
-  govuk-lint: "configs/rubocop/all.yml"
+  rubocop-govuk: "config/all.yml"
+
 AllCops:
     TargetRubyVersion: 2.3
 Metrics/BlockLength:

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development, :test do
   gem 'byebug'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
-  gem 'govuk-lint'
+  gem 'rubocop-govuk'
   gem 'govuk_schemas', '4.0.0'
   gem 'listen'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,11 +124,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.12)
-    govuk-lint (4.1.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -156,7 +151,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.3)
+    jaro_winkler (1.5.4)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     json (2.2.0)
@@ -333,6 +328,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (0.2.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -341,16 +340,9 @@ GEM
     ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     scenic (1.5.1)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (4.1.2)
@@ -438,7 +430,6 @@ DEPENDENCIES
   gds-api-adapters (~> 60.1.0)
   gds-sso
   google-api-client (~> 0.33)
-  govuk-lint
   govuk_app_config
   govuk_message_queue_consumer (~> 3.5)
   govuk_schemas (= 4.0.0)
@@ -460,6 +451,7 @@ DEPENDENCIES
   rails-erd
   rspec-its
   rspec-rails
+  rubocop-govuk
   ruby-progressbar
   scenic
   shoulda-matchers


### PR DESCRIPTION
As `govuk-lint` is soon to be deprecated. This style rules will remain the same.
