### PR TITLE
Add the government schema

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -12,6 +12,7 @@ class Etl::Edition::Content::Parsers::NoContent
       facet_group
       facet_value
       generic
+      government
       homepage
       knowledge_alpha
       organisations_homepage


### PR DESCRIPTION
This is a new schema, to be used by Whitehall publisher when
publishing governments to the Publishing API. It currently contains no
content.
