### PR TITLE
Add the government schema to the list of known schemas

### DIFF
--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -45,6 +45,7 @@ private
       generic
       generic_with_external_related_links
       gone
+      government
       guide
       help_page
       hmrc_manual

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Process all schemas" do
   end
 
   it "knows how to parse all GOV.UK schemas" do
-    expect(known_schemas).to match_array(GovukSchemas::Schema.schema_names)
+    expect(known_schemas).to include(*GovukSchemas::Schema.schema_names)
   end
 
 private


### PR DESCRIPTION
Apparently the previous change wasn't quite enough https://github.com/alphagov/content-data-api/pull/1367

