### PR TITLE
Update where the government details can be found

### DIFF
--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -86,7 +86,14 @@ private
   end
 
   def historical?
-    @payload.dig("details", "government").present? && !@payload.dig("details", "government", "current")
+    government_current = @payload.dig(
+      "expanded_links", "government", 0, "details", "current"
+    )
+
+    # Treat no government as not historical
+    return false if government_current.nil?
+
+    !government_current
   end
 
   def mandatory_fields_nil?

--- a/spec/support/shared/shared_messages.rb
+++ b/spec/support/shared/shared_messages.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples "BaseMessage#historically_political?" do
     context "when payload has current goverment as false and has political as true" do
       before {
         payload["details"]["political"] = true
-        payload["details"]["government"]["current"] = false
+        payload["expanded_links"]["government"] = [{ "details" => { "current" => false } }]
       }
       it { is_expected.to eq true }
     end
@@ -29,7 +29,7 @@ RSpec.shared_examples "BaseMessage#historically_political?" do
     end
 
     context "when payload has current goverment as true" do
-      before { payload["details"]["government"]["current"] = true }
+      before { payload["expanded_links"]["government"] = [{ "details" => { "current" => true } }] }
       it { is_expected.to eq false }
     end
   end


### PR DESCRIPTION
Work is underway to link content to it's associated government, which
removes the need to have information about the government in the
details of the content.

This will allow the Publishing API to take care of updating the
content items when the government becomes historical.

Once all relevant content is linked to the right government, this
change can be merged to ensure the Content Data API has access to up
to date information.