### PR TITLE
Remove Content Audit Tool

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,6 @@ Rails.application.routes.draw do
 
   resources :items, only: %w(index show), param: :content_id
 
-  get "/audits", to: redirect(Plek.find("content-audit-tool", status: 302))
-
   namespace :api, defaults: { format: :json } do
     get "/v1/metrics/", to: "metrics#index"
     get "/v1/healthcheck", to: "healthcheck#index"

--- a/spec/requests/routing/redirect_audits_route_spec.rb
+++ b/spec/requests/routing/redirect_audits_route_spec.rb
@@ -1,8 +1,0 @@
-RSpec.describe "/audits", type: :request do
-  describe "audits" do
-    it "redirects to the Content Audit Tool" do
-      get "/audits"
-      expect(response).to redirect_to(Plek.find("content-audit-tool"))
-    end
-  end
-end


### PR DESCRIPTION
Content Audit Tool is a legacy application created before Content Data. It was used to help tag content - it shared a codebase with Content Performance Manager.

It is being retired as it should no longer be used, to clean up references to it in our codebase, and remove the need for developers to maintain it.

[Trello](https://trello.com/c/V6bXwwtx/1700-3-retire-content-audit-app)
