### PR TITLE
Add retries for GA client

### DIFF
--- a/app/domain/etl/ga/client.rb
+++ b/app/domain/etl/ga/client.rb
@@ -12,6 +12,10 @@ class Etl::GA::Client
   def build(scope: AUTH_ANALYTICS_READONLY)
     @client ||= AnalyticsReportingService.new
     @client.authorization ||= ServiceAccountCredentials.make_creds(scope: scope)
+
+    @client.client_options.read_timeout_sec = 300
+    @client.client_options.open_timeout_sec = 300
+    @client.request_options.retries = 3
     @client
   end
 end


### PR DESCRIPTION
# Description
Currently we are experiencing intermittent API timeouts for GA in the ETL process. Setting the retry option and timeout limits to allow the Google API client automatically retry the request on timeout.