### PR TITLE
Allow content data to be returned by month

### DIFF
--- a/app/domain/api/content_request.rb
+++ b/app/domain/api/content_request.rb
@@ -1,8 +1,9 @@
 class Api::ContentRequest
   VAILD_SORT_ATTRIBUTES = (Metric.daily_metrics.map(&:name) + %w[title document_type]).freeze
   VALID_SORT_DIRECTIONS = %w[asc desc].freeze
-  VALID_TIME_PERIODS = ["past-30-days", "last-month", "past-3-months", "past-6-months", "past-year"].freeze
+  VALID_TIME_PERIODS = SpecificMonths::VALID_SPECIFIC_MONTHS + ["past-30-days", "last-month", "past-3-months", "past-6-months", "past-year"].freeze
   include ActiveModel::Validations
+  include SpecificMonths
 
   attr_reader :organisation_id, :document_type, :page, :page_size, :date_range, :search_term
   validate :valid_organisation_id

--- a/app/domain/api/document_children_request.rb
+++ b/app/domain/api/document_children_request.rb
@@ -1,8 +1,9 @@
 class Api::DocumentChildrenRequest
   VAILD_SORT_KEYS = (Metric.daily_metrics.map(&:name) + %w[title document_type sibling_order]).freeze
   VALID_SORT_DIRECTIONS = %w[asc desc].freeze
-  VALID_TIME_PERIODS = ["past-30-days", "last-month", "past-3-months", "past-6-months", "past-year"].freeze
+  VALID_TIME_PERIODS = SpecificMonths::VALID_SPECIFIC_MONTHS + ["past-30-days", "last-month", "past-3-months", "past-6-months", "past-year"].freeze
   include ActiveModel::Validations
+  include SpecificMonths
 
   validate :valid_time_period
   validate :valid_sort_key

--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -65,7 +65,10 @@ private
         sum(entrances),
         sum(searches),
         sum(feedex),
-        sum(satisfaction),
+        CASE
+          WHEN ((sum(useful_yes) + sum(useful_no)) = 0) THEN NULL::double precision
+          ELSE (sum(useful_yes)::double precision / ((sum(useful_yes) + sum(useful_no)))::double precision)
+        END AS satisfaction,
         sum(useful_yes),
         sum(useful_no),
         sum(exits),

--- a/app/domain/finders/select_view.rb
+++ b/app/domain/finders/select_view.rb
@@ -1,4 +1,5 @@
 class Finders::SelectView
+  include SpecificMonths
   attr_reader :date_range
 
   def initialize(date_range)
@@ -14,6 +15,8 @@ class Finders::SelectView
 private
 
   def model_name
+    return ::Aggregations::MonthlyMetric if specified_month
+
     aggregations = {
       "last-month" => ::Aggregations::SearchLastMonth,
       "past-3-months" => ::Aggregations::SearchLastThreeMonths,
@@ -24,6 +27,8 @@ private
   end
 
   def table_name
+    return "aggregations_monthly_metrics" if specified_month
+
     table_names = {
       "last-month" => "last_months",
       "past-3-months" => "last_three_months",
@@ -34,7 +39,11 @@ private
   end
 
   def valid_date_range?
-    ["past-30-days", "last-month", "past-3-months", "past-6-months", "past-year"].include?(date_range)
+    specified_month || ["past-30-days", "last-month", "past-3-months", "past-6-months", "past-year"].include?(date_range)
+  end
+
+  def specified_month
+    @specified_month ||= SpecificMonths::VALID_SPECIFIC_MONTHS.include?(date_range)
   end
 
   class InvalidDateRangeError < StandardError

--- a/app/domain/specific_months.rb
+++ b/app/domain/specific_months.rb
@@ -1,0 +1,10 @@
+module SpecificMonths
+  YEARS = (2018..Time.zone.today.year).to_a.freeze
+  MONTHS = Date::MONTHNAMES.compact.freeze
+
+  VALID_SPECIFIC_MONTHS = YEARS.flat_map do |year|
+    MONTHS.map do |month|
+      "#{month.downcase}-#{year}"
+    end
+  end
+end

--- a/spec/domain/etl/aggregations/monthly_spec.rb
+++ b/spec/domain/etl/aggregations/monthly_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Etl::Aggregations::Monthly do
   let(:edition2) { create :edition, base_path: "/path2", live: true, date: "2018-02-20" }
 
   it "calculates monthly aggregations for a given date" do
-    create :metric, edition: edition1, date: "2018-02-20", pviews: 20, upviews: 10
-    create :metric, edition: edition1, date: "2018-02-21", pviews: 40, upviews: 20
-    create :metric, edition: edition1, date: "2018-02-22", pviews: 60, upviews: 30
+    create :metric, edition: edition1, date: "2018-02-20", pviews: 20, upviews: 10, useful_yes: 50, useful_no: 50
+    create :metric, edition: edition1, date: "2018-02-21", pviews: 40, upviews: 20, useful_yes: 50, useful_no: 50
+    create :metric, edition: edition1, date: "2018-02-22", pviews: 60, upviews: 30, useful_yes: 50, useful_no: 50
 
-    create :metric, edition: edition2, date: "2018-02-20", pviews: 100, upviews: 10
-    create :metric, edition: edition2, date: "2018-02-21", pviews: 200, upviews: 20
+    create :metric, edition: edition2, date: "2018-02-20", pviews: 100, upviews: 10, useful_yes: 50, useful_no: 50
+    create :metric, edition: edition2, date: "2018-02-21", pviews: 200, upviews: 20, useful_yes: 50, useful_no: 50
 
     subject.process(date: date)
 
@@ -25,11 +25,13 @@ RSpec.describe Etl::Aggregations::Monthly do
       dimensions_edition_id: edition1.id,
       pviews: 120,
       upviews: 60,
+      satisfaction: 0.5,
     )
     expect(results.second).to have_attributes(
       dimensions_edition_id: edition2.id,
       pviews: 300,
       upviews: 30,
+      satisfaction: 0.5,
     )
   end
 
@@ -65,7 +67,7 @@ RSpec.describe Etl::Aggregations::Monthly do
     )
   end
 
-  Metric.daily_metrics.map(&:name).each do |metric_name|
+  Metric.daily_metrics.reject { |metric| metric.name == "satisfaction" }.map(&:name).each do |metric_name|
     it "Calculates aggregations for metric: `#{metric_name}`" do
       create :metric, edition: edition1, date: "2018-02-21", metric_name => 10
       create :metric, edition: edition1, date: "2018-02-22", metric_name => 20

--- a/spec/domain/finders/content_spec.rb
+++ b/spec/domain/finders/content_spec.rb
@@ -147,6 +147,22 @@ RSpec.describe Finders::Content do
         hash_including(upviews: 25, searches: 21, satisfaction: 0.5),
       )
     end
+
+    it "returns aggregations for a specific month" do
+      august2019 = Date.new(2019, 8, 1)
+      create :metric, edition: edition1, date: this_month_date, upviews: 15, useful_yes: 1, useful_no: 4, searches: 10
+      create :metric, edition: edition1, date: august2019, upviews: 20, useful_yes: 4, useful_no: 1, searches: 1
+      create :metric, edition: edition2, date: august2019, upviews: 10, useful_yes: 4, useful_no: 1, searches: 11
+
+      recalculate_aggregations!
+
+      response = described_class.call(filter: filter.merge(date_range: "august-2019"))
+
+      expect(response[:results]).to contain_exactly(
+        hash_including(upviews: 20, searches: 1, satisfaction: 0.8),
+        hash_including(upviews: 10, searches: 11, satisfaction: 0.8),
+      )
+    end
   end
 
   describe "Filter by all document types" do

--- a/spec/domain/finders/select_view_spec.rb
+++ b/spec/domain/finders/select_view_spec.rb
@@ -21,5 +21,9 @@ RSpec.describe Finders::SelectView do
     it "returns last year view if date range is `past-year`" do
       expect(described_class.new("past-year").run).to eq(model_name: Aggregations::SearchLastTwelveMonths, table_name: "last_twelve_months")
     end
+
+    it "returns a specific month if the date range is a valid specified month" do
+      expect(described_class.new("november-2019").run).to eq(model_name: Aggregations::MonthlyMetric, table_name: "aggregations_monthly_metrics")
+    end
   end
 end


### PR DESCRIPTION
This PR extends the content-data-api to receive a date_range param with a specified month and year, in addition to the preset date ranges.

In order to retrieve the correct data it also updates the monthly aggregations logic to present the "satisfaction" data as a ratio rather than a sum, in line with logic elsewhere in the api.

This change is for a specific use-case and is not being presented in the content-data-admin UI.

[dependent content-data-admin PR](https://github.com/alphagov/content-data-admin/pull/753)
[trello](https://trello.com/c/OKYeyYHe/1799-5-allow-content-data-api-and-content-data-admin-to-return-data-by-month)