### PR TITLE
Bump govuk-rubocop 3.1.0 => 3.2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,16 @@ inherit_gem:
     - "config/default.yml"
     - "config/rails.yml"
 
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
-    TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.3
+  Exclude:
+    - "db/migrate/201*.rb"
+    - "db/schema.rb"
+
 Metrics/BlockLength:
   Exclude:
     - "Rakefile"

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development, :test do
   gem 'byebug'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
-  gem 'rubocop-govuk', '~> 3'
+  gem 'rubocop-govuk', '~> 3.2'
   gem 'govuk_schemas', '4.0.0'
   gem 'listen'
   gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -1,57 +1,57 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-ruby File.read('.ruby-version').chomp
+ruby File.read(".ruby-version").chomp
 
 # GOV.UK gems and forks
-gem 'gds-api-adapters', '~> 63.5.1'
-gem 'gds-sso'
-gem 'govuk_app_config'
-gem 'govuk_sidekiq', '~> 3'
-gem 'plek'
+gem "gds-api-adapters", "~> 63.5.1"
+gem "gds-sso"
+gem "govuk_app_config"
+gem "govuk_sidekiq", "~> 3"
+gem "plek"
 
 # Third party gems
-gem 'active_model_serializers'
-gem 'activerecord-import'
-gem 'awesome_print'
-gem 'google-api-client', '~> 0.37'
-gem 'govuk_message_queue_consumer', '~> 3.5'
-gem 'httparty'
-gem 'jbuilder'
-gem 'kaminari'
-gem 'nokogiri', '~> 1.10'
-gem 'odyssey'
-gem 'pg'
-gem 'rack-proxy'
-gem 'rails', '~> 5.2'
-gem 'rails-erd'
-gem 'ruby-progressbar'
-gem 'scenic'
-gem 'uuid'
+gem "active_model_serializers"
+gem "activerecord-import"
+gem "awesome_print"
+gem "google-api-client", "~> 0.37"
+gem "govuk_message_queue_consumer", "~> 3.5"
+gem "httparty"
+gem "jbuilder"
+gem "kaminari"
+gem "nokogiri", "~> 1.10"
+gem "odyssey"
+gem "pg"
+gem "rack-proxy"
+gem "rails", "~> 5.2"
+gem "rails-erd"
+gem "ruby-progressbar"
+gem "scenic"
+gem "uuid"
 
 group :development do
-  gem 'better_errors'
-  gem 'binding_of_caller'
-  gem 'web-console'
+  gem "better_errors"
+  gem "binding_of_caller"
+  gem "web-console"
 end
 
 group :development, :test do
-  gem 'byebug'
-  gem 'database_cleaner'
-  gem 'factory_bot_rails'
-  gem 'rubocop-govuk', '~> 3.2'
-  gem 'govuk_schemas', '4.0.0'
-  gem 'listen'
-  gem 'pry-byebug'
-  gem 'pry-rails'
+  gem "byebug"
+  gem "database_cleaner"
+  gem "factory_bot_rails"
+  gem "govuk_schemas", "4.0.0"
+  gem "listen"
+  gem "pry-byebug"
+  gem "pry-rails"
   gem "rack", ">= 2.0.6"
-  gem 'rails-controller-testing'
-  gem 'rspec-its'
-  gem 'rspec-rails'
-  gem 'shoulda-matchers'
-  gem 'simplecov', require: false
-  gem 'spring'
-  gem 'spring-commands-rspec'
-  gem 'spring-watcher-listen'
-  gem 'timecop'
-  gem 'webmock'
+  gem "rails-controller-testing"
+  gem "rspec-its"
+  gem "rspec-rails"
+  gem "rubocop-govuk", "~> 3.2"
+  gem "shoulda-matchers"
+  gem "simplecov", require: false
+  gem "spring"
+  gem "spring-commands-rspec"
+  gem "spring-watcher-listen"
+  gem "timecop"
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,7 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-govuk (3.1.0)
+    rubocop-govuk (3.2.0)
       rubocop (= 0.80.1)
       rubocop-rails (~> 2)
       rubocop-rspec (~> 1.28)
@@ -450,7 +450,7 @@ DEPENDENCIES
   rails-erd
   rspec-its
   rspec-rails
-  rubocop-govuk (~> 3)
+  rubocop-govuk (~> 3.2)
   ruby-progressbar
   scenic
   shoulda-matchers

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks
 
 namespace :lint do
-  task :ruby do
+  task ruby: :environment do
     sh "bundle exec rubocop --parallel app config lib spec"
   end
 end

--- a/doc/api/Gemfile
+++ b/doc/api/Gemfile
@@ -1,11 +1,11 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # For faster file watcher updates on Windows:
-gem 'wdm', '~> 0.1.0', platforms: %i[mswin mingw]
+gem "wdm", "~> 0.1.0", platforms: %i[mswin mingw]
 
 # Windows does not come with time zone data
-gem 'tzinfo-data', platforms: %i[mswin mingw jruby]
+gem "tzinfo-data", platforms: %i[mswin mingw jruby]
 
-gem 'govuk_tech_docs'
+gem "govuk_tech_docs"
 
-gem 'middleman-gh-pages', '~> 0.3.1'
+gem "middleman-gh-pages", "~> 0.3.1"

--- a/doc/api/Rakefile
+++ b/doc/api/Rakefile
@@ -1,1 +1,1 @@
-require 'middleman-gh-pages'
+require "middleman-gh-pages"

--- a/doc/api/config.rb
+++ b/doc/api/config.rb
@@ -1,4 +1,4 @@
-require 'govuk_tech_docs'
+require "govuk_tech_docs"
 
 GovukTechDocs.configure(self)
 


### PR DESCRIPTION
This PR bumps govuk-rubocop to 3.2.0, excludes old migrations and the schema from linting, and corrects the following linting errors:

Bundler/OrderedGems
Rails/RakeEnvironment
Style/StringLiterals