### PR TITLE
Add ministers index schema

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -15,6 +15,7 @@ class Etl::Edition::Content::Parsers::NoContent
       government
       homepage
       knowledge_alpha
+      ministers_index
       organisations_homepage
       person
       placeholder_corporate_information_page

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       generic
       homepage
       knowledge_alpha
+      ministers_index
       organisations_homepage
       person
       placeholder_corporate_information_page

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -58,6 +58,7 @@ private
       mainstream_browse_page
       manual
       manual_section
+      ministers_index
       need
       news_article
       organisation


### PR DESCRIPTION
This is a new schema, currently used by Whitehall

Trello card: https://trello.com/c/J8HCsPIV/1823-5-add-a-content-schema-for-ministers-index-page

# Description
What are the changes? Why are you making these changes?

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
