### PR TITLE
Remove placeholder_working_group

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -24,7 +24,6 @@ class Etl::Edition::Content::Parsers::NoContent
       placeholder_organisation
       placeholder_policy_area
       placeholder_topical_event
-      placeholder_working_group
       placeholder_world_location
       placeholder_worldwide_organisation
       placeholder_person

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Etl::Edition::Content::Parser do
       placeholder_organisation
       placeholder_policy_area
       placeholder_topical_event
-      placeholder_working_group
       placeholder_world_location
       placeholder_worldwide_organisation
       placeholder_person


### PR DESCRIPTION
This removes the document type placeholder_working_group as it is no
longer used.

Trello:
https://trello.com/c/ygOqmhWw/1921-remove-legacy-placeholderworkinggroup-code-data-from-govuks-codebase