### PR TITLE
Add support for new history page schema

### DIFF
--- a/app/domain/etl/edition/content/parsers/body_content.rb
+++ b/app/domain/etl/edition/content/parsers/body_content.rb
@@ -22,6 +22,7 @@ class Etl::Edition::Content::Parsers::BodyContent
       document_collection
       fatality_notice
       help_page
+      history
       hmrc_manual_section
       html_publication
       manual

--- a/spec/domain/etl/edition/content/body_content_spec.rb
+++ b/spec/domain/etl/edition/content/body_content_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       document_collection
       fatality_notice
       help_page
+      history
       hmrc_manual_section
       html_publication
       manual

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -49,6 +49,7 @@ private
       government
       guide
       help_page
+      history
       hmrc_manual
       hmrc_manual_section
       homepage


### PR DESCRIPTION
# Description
Add support for the `history` schema: https://github.com/alphagov/govuk-content-schemas/pull/988

[Trello card](https://trello.com/c/6IveqNKB/1982-3-render-10-downing-street-in-government-frontend)

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
