### PR TITLE
Fix contradictory warning and add diagnostic information

### DIFF
--- a/app/domain/healthchecks/daily_metrics_check.rb
+++ b/app/domain/healthchecks/daily_metrics_check.rb
@@ -11,7 +11,7 @@ module Healthchecks
     end
 
     def message
-      "ETL :: no daily metrics for yesterday"
+      "ETL :: no daily metrics for yesterday" if status == :critical
     end
 
   private

--- a/app/domain/streams/consumer.rb
+++ b/app/domain/streams/consumer.rb
@@ -9,7 +9,7 @@ module Streams
 
       message.ack
     rescue StandardError => e
-      GovukError.notify(e)
+      GovukError.notify(e, extra: { payload: message.payload })
       message.discard
     end
 

--- a/spec/domain/healthchecks/daily_metrics_check_spec.rb
+++ b/spec/domain/healthchecks/daily_metrics_check_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe Healthchecks::DailyMetricsCheck do
       it "returns status :ok" do
         expect(subject.status).to eq(:ok)
       end
-
-      it "returns a detailed message" do
-        expect(subject.message).to eq("ETL :: no daily metrics for yesterday")
-      end
     end
 
     context "When there are no metrics" do
-      it "returns status :ok" do
+      it "returns status :critical" do
         expect(subject.status).to eq(:critical)
+      end
+
+      it "returns a detailed message" do
+        expect(subject.message).to eq("ETL :: no daily metrics for yesterday")
       end
     end
   end

--- a/spec/domain/streams/consumer_spec.rb
+++ b/spec/domain/streams/consumer_spec.rb
@@ -6,4 +6,16 @@ RSpec.describe Streams::Consumer do
 
     subject.process(message)
   end
+
+  it "sends payload information to GovukError" do
+    error = StandardError.new
+    allow(Streams::MessageProcessorJob).to receive(:perform_later).and_raise(error)
+    expect(GovukError).to receive(:notify).with(error, extra: { payload: hash_including(
+      "content_id" => an_instance_of(String),
+      "base_path" => an_instance_of(String),
+      # there are many more properties, but these are the only ones we need for debugging
+    ) })
+
+    subject.process(build(:message))
+  end
 end

--- a/spec/integration/streams/errors_spec.rb
+++ b/spec/integration/streams/errors_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Streams::Consumer do
     end
 
     it "logs the error" do
-      expect(GovukError).to receive(:notify).with(instance_of(StandardError))
+      expect(GovukError).to receive(:notify).with(instance_of(StandardError), hash_including(:extra))
 
       expect { subject.process(message) }.to_not raise_error
     end


### PR DESCRIPTION
# Description
See commits for details. This PR fixes one warning where we're erroneously being told we're missing daily metrics. It also adds `payload` diagnostic information to help us get to the bottom of sidekiq retry errors which are currently a little ambiguous.

Trello: https://trello.com/c/2wiNWp19/2065-investigation-content-data-api-app-healthcheck-not-ok-timebox-2-day

---
# Review Checklist
* [ ] Changes in scope.
* [x] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
