### PR TITLE
Call GovukError.notify with IDs of old and new editions

### DIFF
--- a/app/domain/streams/consumer.rb
+++ b/app/domain/streams/consumer.rb
@@ -9,7 +9,7 @@ module Streams
 
       message.ack
     rescue StandardError => e
-      GovukError.notify(e, extra: { payload: message.payload })
+      GovukError.notify(e)
       message.discard
     end
 

--- a/spec/domain/streams/consumer_spec.rb
+++ b/spec/domain/streams/consumer_spec.rb
@@ -7,14 +7,10 @@ RSpec.describe Streams::Consumer do
     subject.process(message)
   end
 
-  it "sends payload information to GovukError" do
+  it "sends an error to GovukError" do
     error = StandardError.new
     allow(Streams::MessageProcessorJob).to receive(:perform_later).and_raise(error)
-    expect(GovukError).to receive(:notify).with(error, extra: { payload: hash_including(
-      "content_id" => an_instance_of(String),
-      "base_path" => an_instance_of(String),
-      # there are many more properties, but these are the only ones we need for debugging
-    ) })
+    expect(GovukError).to receive(:notify).with(error)
 
     subject.process(build(:message))
   end

--- a/spec/integration/streams/errors_spec.rb
+++ b/spec/integration/streams/errors_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Streams::Consumer do
     end
 
     it "logs the error" do
-      expect(GovukError).to receive(:notify).with(instance_of(StandardError), hash_including(:extra))
+      expect(GovukError).to receive(:notify).with(instance_of(StandardError))
 
       expect { subject.process(message) }.to_not raise_error
     end


### PR DESCRIPTION
This diagnostic code was originally added in the wrong place:
https://github.com/alphagov/content-data-api/pull/1522/files

Currently it is hard to know exactly which Dimensions::Edition
is being updated - no edition ID exists in Sentry:
https://sentry.io/organizations/govuk/issues/1517959668/?environment=production&project=1461890&query=is%3Aunresolved

This commit attempts to add more diagnostic information, so
that we know exactly what payload has caused the error.
It removes the code from the place it was incorrectly added to,
and edits the test to reflect reality. There is no corresponding
test for base_handler.rb, and it didn't seem worthwhile to add
one given its value and the complexity of testing a private
method.

I've checked and the RecordNotUnique error does not get filtered
out upstream, so we are safe to pass this to GovukError.notify:
https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/configure.rb

Trello card: https://trello.com/c/2wiNWp19/2065-investigation-content-data-api-app-healthcheck-not-ok-timebox-2-day

# Description
What are the changes? Why are you making these changes?

---
# Review Checklist
* [ ] Changes in scope.
* [x] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
