### PR TITLE
Remove diagnostic code

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -40,12 +40,7 @@ class Dimensions::Edition < ApplicationRecord
 
   def promote!(old_edition)
     old_edition.update!(live: false) if old_edition
-    begin
-      update!(live: true) unless unpublished?
-    rescue PG::UniqueViolation, ActiveRecord::RecordNotUnique => e
-      GovukError.notify(e, extra: { old_edition_id: old_edition.id, new_edition_id: id })
-      raise e
-    end
+    update!(live: true) unless unpublished?
   end
 
   def unpublished?

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -94,9 +94,9 @@ RSpec.describe Dimensions::Edition, type: :model do
 
   describe "#promote!" do
     context "for published edition" do
-      let(:edition) { build :edition, id: 1, live: false }
+      let(:edition) { build :edition, live: false }
       let(:warehouse_item_id) { "warehouse-item-id" }
-      let(:old_edition) { build :edition, id: 2, warehouse_item_id: warehouse_item_id }
+      let(:old_edition) { build :edition, warehouse_item_id: warehouse_item_id }
 
       it "set the live attribute to true" do
         edition.promote!(old_edition)
@@ -106,16 +106,6 @@ RSpec.describe Dimensions::Edition, type: :model do
       it "sets the live attribute to false for the old version" do
         edition.promote!(old_edition)
         expect(old_edition.live).to be false
-      end
-
-      it "raises an exception if it encounters an issue, and sends payload information to GovukError" do
-        exception = PG::UniqueViolation.new("ERROR: duplicate key value violates unique constraint")
-        allow(edition).to receive(:update!).and_raise(exception)
-        expect(GovukError).to receive(:notify).with(exception, extra: {
-          old_edition_id: old_edition.id,
-          new_edition_id: edition.id,
-        })
-        expect { edition.promote!(old_edition) }.to raise_exception(exception)
       end
     end
 

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Dimensions::Edition, type: :model do
   end
 
   describe ".find_latest" do
-    it "return the most recent editon for a content item" do
+    it "returns the most recent editon for a content item" do
       content_id = SecureRandom.uuid
       edition1 = create :edition, content_id: content_id, locale: "en"
       edition2 = create :edition, content_id: content_id, locale: "en", replaces: edition1
@@ -50,7 +50,7 @@ RSpec.describe Dimensions::Edition, type: :model do
       expect(latest_edition).to eq(edition2)
     end
 
-    it "return the most recent editon for a content item for locale" do
+    it "returns the most recent editon for a content item for locale" do
       content_id = SecureRandom.uuid
       edition1 = create :edition, content_id: content_id, locale: "en"
       edition2 = create :edition, content_id: content_id, locale: "en", replaces: edition1
@@ -61,7 +61,7 @@ RSpec.describe Dimensions::Edition, type: :model do
       expect(latest_edition).to eq(edition2)
     end
 
-    it "return the most recent editon for content id" do
+    it "returns the most recent editon for content id" do
       content_id = SecureRandom.uuid
       edition1 = create :edition, content_id: content_id, locale: "en"
       edition2 = create :edition, content_id: content_id, locale: "en", replaces: edition1
@@ -73,7 +73,7 @@ RSpec.describe Dimensions::Edition, type: :model do
       expect(latest_edition).to eq(edition2)
     end
 
-    it "return nil for no edition for locale" do
+    it "returns nil for no edition for locale" do
       create :edition, locale: "cy"
       content_id = SecureRandom.uuid
 
@@ -82,7 +82,7 @@ RSpec.describe Dimensions::Edition, type: :model do
       expect(latest_edition).to eq(nil)
     end
 
-    it "return nil for no edition for content_id" do
+    it "returns nil for no edition for content_id" do
       create :edition
       other_content_id = SecureRandom.uuid
 
@@ -98,7 +98,7 @@ RSpec.describe Dimensions::Edition, type: :model do
       let(:warehouse_item_id) { "warehouse-item-id" }
       let(:old_edition) { build :edition, warehouse_item_id: warehouse_item_id }
 
-      it "set the live attribute to true" do
+      it "sets the live attribute to true" do
         edition.promote!(old_edition)
         expect(edition.live).to be true
       end
@@ -114,7 +114,7 @@ RSpec.describe Dimensions::Edition, type: :model do
       let(:warehouse_item_id) { "warehouse-item-id" }
       let(:old_edition) { build :edition, warehouse_item_id: warehouse_item_id }
 
-      it "set the live attribute to true" do
+      it "sets the live attribute to false" do
         edition.promote!(old_edition)
         expect(edition.live).to be false
       end
@@ -238,13 +238,19 @@ RSpec.describe Dimensions::Edition, type: :model do
   end
 
   describe "Unique constraint on `base_path` and `live`" do
-    it "prevent duplicating `base_path` for live items" do
+    it "prevents duplicating `base_path` for live items" do
       create :edition, base_path: "value", live: true
 
       expect(-> { create :edition, base_path: "value", live: true }).to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it "does not prevent duplicating `base_path` for old items" do
+      create :edition, base_path: "value", live: true
+
+      expect(-> { create :edition, base_path: "value", live: false }).to_not raise_error
+    end
+
+    it "does not prevent duplicating `base_path` for unpublished items" do
       create :edition, base_path: "value", live: true
 
       expect(-> { create :edition, base_path: "value", live: false }).to_not raise_error


### PR DESCRIPTION
# Description
Remove diagnostic code added in 5a1d024

As explained in 27ea29b:

> We expect to have errors related to duplicated editions from time to time
> because we can’t guarantee the order in which we receive the messages.
> Sometimes they might run at the same time.
>
> By adding the retry at the Job level, we aim to prevent having actionable
> errors in Sentry.

By adding this diagnostic code, I've exposed a lot of 'transient'
errors in Sentry that are not actionable. It's served its
usefulness now and should be removed.

Trello: https://trello.com/c/2wiNWp19/2065-investigation-content-data-api-app-healthcheck-not-ok-timebox-2-day

---
# Review Checklist
* [ ] Changes in scope.
* [x] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
