### PR TITLE
Removes accidentally committed code

### DIFF
--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -249,11 +249,5 @@ RSpec.describe Dimensions::Edition, type: :model do
 
       expect(-> { create :edition, base_path: "value", live: false }).to_not raise_error
     end
-
-    it "does not prevent duplicating `base_path` for unpublished items" do
-      create :edition, base_path: "value", live: true
-
-      expect(-> { create :edition, base_path: "value", live: false }).to_not raise_error
-    end
   end
 end


### PR DESCRIPTION
I stubbed out a test I intended to write as part of
https://trello.com/c/2wiNWp19/2065-investigation-content-data-api-app-healthcheck-not-ok-timebox-2-day
but didn't get further with it.

It accidentally got committed to https://github.com/alphagov/content-data-api/pull/1526

... 🤦  

# Description
What are the changes? Why are you making these changes?

---
# Review Checklist
* [ ] Changes in scope.
* [x] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
