### PR TITLE
Update govuk_app_config to v2.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
-    govuk_app_config (2.5.0)
+    govuk_app_config (2.5.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.4.0)


### PR DESCRIPTION
# Description
This is to enable the new 'data_sync_excluded_exceptions' feature:
https://github.com/alphagov/govuk_app_config/blob/master/CHANGELOG.md#251

By [default], any errors of type `PG::Error` are excluded from
reporting to Sentry, if they occur during the nightly [data sync].

Overnight we saw ~1000 errors in Sentry:

```
ActiveRecord::StatementInvalid Sidekiq/Streams::MessageProcessorJob
PG::UndefinedTable: ERROR: relation "dimensions_editions" does not exist LINE 2: FROM
```

These should be disabled during data sync as they are expected
errors.

[data sync]: https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html
[default]: https://github.com/alphagov/govuk_app_config/blob/d041c5a868f092d196c126523cc1593a601da89b/lib/govuk_app_config/govuk_error/configure.rb#L52

Trello: https://trello.com/c/rAlvGlSp/2123-5-ignore-data-sync-errors-in-govukappconfig

---
# Review Checklist
* [x] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
