### PR TITLE
Account for leap year in 'day of year' validation

### DIFF
--- a/app/models/dimensions/date.rb
+++ b/app/models/dimensions/date.rb
@@ -75,7 +75,7 @@ class Dimensions::Date < ApplicationRecord
   validates :day_of_year,
             presence: true,
             numericality: { only_integer: true },
-            inclusion: { in: (1..365) }
+            inclusion: { in: (1..366) }
 
   validates :day_of_quarter,
             presence: true,

--- a/spec/models/dimensions/date_spec.rb
+++ b/spec/models/dimensions/date_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Dimensions::Date, type: :model do
 
   it { is_expected.to validate_presence_of(:day_of_year) }
   it { is_expected.to validate_numericality_of(:day_of_year).only_integer }
-  it { is_expected.to validate_inclusion_of(:day_of_year).in_range(1..365) }
+  it { is_expected.to validate_inclusion_of(:day_of_year).in_range(1..366) }
 
   it { is_expected.to validate_presence_of(:day_of_quarter) }
   it { is_expected.to validate_numericality_of(:day_of_quarter).only_integer }


### PR DESCRIPTION
The build is failing today (31st December 2020) because 2020 is a
leap year, therefore this year there are 366 days in the year
rather than 365.

I did try conditionally validating the range `1..365` or `1..366`
depending on the outcome of `Date.leap?(year)`, but because of
_when_ the validation happens, `year` is often `nil`, so is not
a reliable attribute to test against. I don't foresee any major
issues by simply allowing the number 366, even if the given year
is not a leap year.

This fix is to enable this Trello card: https://trello.com/c/SSBGIovv/2277-add-albania-to-protected-food-drink-names-finder

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
