### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,6 @@ library("govuk")
 
 node("postgresql-9.6") {
   govuk.buildProject(
-    postgres96Lint: false,
-    rubyLintDiff: false,
-    sassLint: false,
     beforeTest: {
       govuk.setEnvar("TEST_COVERAGE", "true")
     }


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
The rubyLintDiff option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/57
And the postgres lint step was removed in https://github.com/alphagov/govuk-jenkinslib/pull/81

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
