### PR TITLE
Accept placeholder schema

### DIFF
--- a/app/domain/streams/messages/base_message.rb
+++ b/app/domain/streams/messages/base_message.rb
@@ -41,7 +41,7 @@ class Streams::Messages::BaseMessage
   end
 
   def invalid?
-    mandatory_fields_nil? || placeholder_schema?
+    mandatory_fields_nil?
   end
 
   def withdrawn_notice?
@@ -99,9 +99,5 @@ private
   def mandatory_fields_nil?
     mandatory_fields = @payload.values_at("base_path", "schema_name")
     mandatory_fields.any?(&:nil?)
-  end
-
-  def placeholder_schema?
-    @payload["schema_name"].include?("placeholder")
   end
 end

--- a/spec/support/shared/shared_messages.rb
+++ b/spec/support/shared/shared_messages.rb
@@ -65,7 +65,7 @@ RSpec.shared_examples "BaseMessage#invalid?" do
 
     context "when schema name is placeholder" do
       before { payload["schema_name"] = "placeholder" }
-      it { is_expected.to eq true }
+      it { is_expected.to eq false }
     end
 
     context "when base path is nil" do


### PR DESCRIPTION
# Description

Received a request to display topical events in Content Data app https://govuk.zendesk.com/agent/tickets/4454900.

This schema was not originally included, but I am not sure why. Weirdly, topical_event pages use "placeholder" for the schema.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
