### PR TITLE
Add govuk_test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem "database_cleaner"
   gem "factory_bot_rails"
   gem "govuk_schemas"
+  gem "govuk_test"
   gem "listen"
   gem "pry-byebug"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,12 +75,22 @@ GEM
     bindex (0.8.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    brakeman (4.10.0)
     builder (3.2.4)
     bunny (2.16.1)
       amq-protocol (~> 2.3, >= 2.3.1)
     byebug (11.1.3)
+    capybara (3.34.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     case_transform (0.2)
       activesupport
+    childprocess (3.0.0)
     choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
@@ -156,6 +166,12 @@ GEM
       sidekiq (>= 5, < 6)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (>= 2.1)
+    govuk_test (2.0.0)
+      brakeman (~> 4.6)
+      capybara
+      puma
+      selenium-webdriver (>= 3.142)
+      webdrivers (>= 4)
     hashdiff (1.0.1)
     hashie (4.1.0)
     http-accept (1.7.0)
@@ -251,6 +267,8 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
+    puma (5.1.0)
+      nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-protection (2.1.0)
@@ -366,10 +384,14 @@ GEM
       rexml
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.4)
+    rubyzip (2.3.0)
     safe_yaml (1.0.5)
     scenic (1.5.2)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sentry-raven (3.1.1)
       faraday (>= 1.0)
     shoulda-matchers (4.3.0)
@@ -432,6 +454,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -439,6 +465,8 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -460,6 +488,7 @@ DEPENDENCIES
   govuk_message_queue_consumer
   govuk_schemas
   govuk_sidekiq
+  govuk_test
   httparty
   jbuilder
   kaminari

--- a/spec/support/govuk_test.rb
+++ b/spec/support/govuk_test.rb
@@ -1,0 +1,1 @@
+GovukTest.configure


### PR DESCRIPTION
This is a library that we should be using in all our applications to provide a consistent test environment. In this particular case, it brings in a version of Brakeman that won't be automatically updated to the latest version and thus avoids problems of PRs failing due to an external factor.

We should eventually upgrade to a more recent version of Brakeman, however this should be done in coordination with the govuk_test Gem so it's something we do across all our apps at the same time.

See https://github.com/alphagov/govuk_test/pull/28 for more background on why we're doing this.