### PR TITLE
Add search and metrics healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,15 @@ Rails.application.routes.draw do
 
   get "/content", to: "content#show", defaults: { format: :json }
   get "/single_page/(*base_path)", to: "single_item#show", defaults: { format: :json }, format: false
+  get "/healthcheck/search",
+      to: GovukHealthcheck.rack_response(
+        Healthchecks::MonthlyAggregations,
+        Healthchecks::SearchAggregations.build(:last_month),
+        Healthchecks::SearchAggregations.build(:last_six_months),
+        Healthchecks::SearchAggregations.build(:last_thirty_days),
+        Healthchecks::SearchAggregations.build(:last_three_months),
+        Healthchecks::SearchAggregations.build(:last_twelve_months),
+      )
   get "/healthcheck",
       to: GovukHealthcheck.rack_response(
         GovukHealthcheck::ActiveRecord,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,14 @@ Rails.application.routes.draw do
 
   get "/content", to: "content#show", defaults: { format: :json }
   get "/single_page/(*base_path)", to: "single_item#show", defaults: { format: :json }, format: false
+  get "/healthcheck/metrics",
+      to: GovukHealthcheck.rack_response(
+        Healthchecks::DailyMetricsCheck,
+        Healthchecks::EtlMetricValues.build(:pviews),
+        Healthchecks::EtlMetricValues.build(:upviews),
+        Healthchecks::EtlMetricValues.build(:searches),
+        Healthchecks::EtlMetricValues.build(:feedex),
+      )
   get "/healthcheck/search",
       to: GovukHealthcheck.rack_response(
         Healthchecks::MonthlyAggregations,

--- a/spec/requests/healthcheck_metrics_spec.rb
+++ b/spec/requests/healthcheck_metrics_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe "/healthcheck/metrics" do
+  before do
+    get "/healthcheck/metrics"
+  end
+
+  it "returns distinct organisations ordered by title" do
+    json = JSON.parse(response.body)
+
+    expect(json["checks"]).to include("daily_metrics")
+    .and(include("etl_metric_values_pviews"))
+    .and(include("etl_metric_values_searches"))
+    .and(include("etl_metric_values_upviews"))
+    .and(include("etl_metric_values_feedex"))
+  end
+
+  it "is not cacheable" do
+    expect(response.headers["Cache-Control"]).to eq "max-age=0, private, must-revalidate"
+  end
+end

--- a/spec/requests/healthcheck_search_spec.rb
+++ b/spec/requests/healthcheck_search_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe "/healthcheck/search" do
+  before do
+    get "/healthcheck/search"
+  end
+
+  it "returns distinct organisations ordered by title" do
+    json = JSON.parse(response.body)
+
+    expect(json["checks"]).to include("aggregations")
+      .and(include("search_last_month"))
+      .and(include("search_last_six_months"))
+      .and(include("search_last_thirty_days"))
+      .and(include("search_last_three_months"))
+      .and(include("search_last_twelve_months"))
+  end
+
+  it "is not cacheable" do
+    expect(response.headers["Cache-Control"]).to eq "max-age=0, private, must-revalidate"
+  end
+end


### PR DESCRIPTION
This creates a separate endpoint for the search and metrics healthchecks.

At the moment, a failure in any of these will report the application instance as being `critical` in Icinga, once per node.  This should be measured on per application (rather than per node) basis.

In a later commit, we will remove these metrics from the main application healthcheck. This means we can have a separate alert in Icinga for the search (once, rather than per instance) rather than marking each instance as critical.

Trello card: https://trello.com/c/X2AKAUKn and https://trello.com/c/aDoOuYf5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️