### PR TITLE
Add smart answer schema in known schemas

### DIFF
--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -80,6 +80,7 @@ private
       service_manual_topic
       service_sign_in
       simple_smart_answer
+      smart_answer
       special_route
       specialist_document
       speech


### PR DESCRIPTION
A new schema type "smart_answer" will be added to govuk_content_schemas. https://github.com/alphagov/govuk-content-schemas/pull/1054

These pages used to be represented by transaction pages, however should still be handled by content data api.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
