### PR TITLE
Decouple content-data-api from Raven

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ require "active_record/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-require_relative "raven"
+require_relative "sentry"
 
 module ContentPerformanceManager
   class Application < Rails::Application

--- a/config/sentry.rb
+++ b/config/sentry.rb
@@ -1,3 +1,3 @@
-Raven.configure do |config|
+GovukError.configure do |config|
   config.excluded_exceptions << "ApplicationJob::RetryableError"
 end


### PR DESCRIPTION
Removed direct references to the Raven object and renamed appropriately

Trello: https://trello.com/c/S1QvqyCE/2459-decouple-govuk-apps-from-raven-3

# Description
What are the changes? Why are you making these changes?

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
