### PR TITLE
Revert "Remove 'inherit_mode merge exclude' config from Rubocop"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,7 @@ inherit_gem:
   rubocop-govuk:
     - "config/default.yml"
     - "config/rails.yml"
+
+inherit_mode:
+  merge:
+    - Exclude


### PR DESCRIPTION
This reverts commit 7d3a6c2a9b5ed4fecdca6cff1a747d63e3324afc.
This actually _is_ a pretty standard setup for GOV.UK:
https://docs.publishing.service.gov.uk/manual/configure-linting.html#linting-ruby

I'm not sure why our repo wasn't being fully linted, but we'll
investigate that a bit later. For now, adding back in the standard
config we have.

# Description
What are the changes? Why are you making these changes?

---
# Review Checklist
* [x] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
