### PR TITLE
Bugfix: limit path lengths to 1500

### DIFF
--- a/app/domain/etl/ga/views_and_navigation_service.rb
+++ b/app/domain/etl/ga/views_and_navigation_service.rb
@@ -44,7 +44,7 @@ private
   end
 
   def invalid_record?(data)
-    URI.parse(data["page_path"]).query.present? && data["page_path"].length > PAGE_PATH_LENGTH_LIMIT
+    URI.parse(data["page_path"]) && data["page_path"].length > PAGE_PATH_LENGTH_LIMIT
   rescue URI::InvalidURIError
     true
   end

--- a/spec/domain/etl/ga/views_and_navigation_service_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_service_spec.rb
@@ -79,6 +79,9 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
             build_report_data(
               build_report_row(dimensions: [path_with_long_query], metrics: %w[1 1 1 1 1 1 1 1]),
             ),
+            build_report_data(
+              build_report_row(dimensions: [long_path], metrics: %w[1 1 1 1 1 1 1 1]),
+            ),
           ]
         end
 
@@ -136,6 +139,10 @@ private
 
   def path_with_long_query
     "/foo?q=".concat("a" * 1600)
+  end
+
+  def long_path
+    "/foo".concat("o" * described_class::PAGE_PATH_LENGTH_LIMIT)
   end
 
   def path_with_invalid_uri


### PR DESCRIPTION
Until now we have limited paths to 1500 chars only if they include a query string. However, some paths are very long, so we need to reject those paths (regardless of whether they have a query string) due to a DB limit: index row size maximum is 2712 chars.

We saw some [PG::ProgramLimitExceeded](https://sentry.io/organizations/govuk/issues/2636165771) errors which has motivated this change.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
