### PR TITLE
Use Postgres 13 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,12 @@
 
 library("govuk")
 
-node("postgresql-9.6") {
+node() {
   govuk.buildProject(
     beforeTest: {
+      // Run against the Postgres 13 Docker instance on GOV.UK CI
+      govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/content-data-api-test")
+
       govuk.setEnvar("TEST_COVERAGE", "true")
     }
   )


### PR DESCRIPTION
Uses Postgres13 for CI by setting the TEST_DATABASE_URL environment variable.

[find and view trello](https://trello.com/c/zhH82ATS/955-upgrade-content-data-api-from-postgres-96-to-postgres-13)
[database upgrade trello](https://trello.com/c/hHuLcRMq/3-content-data-api)
