### PR TITLE
Add Topical Event as known schema type

### DIFF
--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -90,6 +90,7 @@ private
       take_part
       taxon
       topic
+      topical_event
       topical_event_about_page
       transaction
       travel_advice


### PR DESCRIPTION
In https://github.com/alphagov/govuk-content-schemas/pull/1093, a `topical_event` schema was added.

Updating the test here as this is a known schema type.

[Trello card](https://trello.com/c/vYckhQzi)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
