### PR TITLE
Add Topical Event schema to body content parser

### DIFF
--- a/app/domain/etl/edition/content/parsers/body_content.rb
+++ b/app/domain/etl/edition/content/parsers/body_content.rb
@@ -37,6 +37,7 @@ class Etl::Edition::Content::Parsers::BodyContent
       speech
       statistical_data_set
       take_part
+      topical_event
       topical_event_about_page
       working_group
       world_location_news_article

--- a/spec/domain/etl/edition/content/body_content_spec.rb
+++ b/spec/domain/etl/edition/content/body_content_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       speech
       statistical_data_set
       take_part
+      topical_event
       topical_event_about_page
       working_group
       world_location_news_article


### PR DESCRIPTION
This was added in https://github.com/alphagov/govuk-content-schemas/pull/1093, so needs to be a document type that content-data-api can parse.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
