### PR TITLE
Add world location news schema to body content parser

### DIFF
--- a/app/domain/etl/edition/content/parsers/body_content.rb
+++ b/app/domain/etl/edition/content/parsers/body_content.rb
@@ -40,6 +40,7 @@ class Etl::Edition::Content::Parsers::BodyContent
       topical_event
       topical_event_about_page
       working_group
+      world_location_news
       world_location_news_article
     ]
   end

--- a/spec/domain/etl/edition/content/body_content_spec.rb
+++ b/spec/domain/etl/edition/content/body_content_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       topical_event
       topical_event_about_page
       working_group
+      world_location_news
       world_location_news_article
     ].freeze
   end


### PR DESCRIPTION
This is being added in https://github.com/alphagov/govuk-content-schemas/pull/1110, so needs to be a document type that content-data-api can parse.

[Trello](https://trello.com/c/FUNRgTWI/168-get-world-news-content-into-content-item)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
