### PR TITLE
Add World Location News as a known schema type

### DIFF
--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -99,6 +99,7 @@ private
       vanish
       working_group
       world_location
+      world_location_news
       world_location_news_article
     ]
   end


### PR DESCRIPTION
This is being added in https://github.com/alphagov/govuk-content-schemas/pull/1110 as part of work to migrate rendering away from whitehall.

[Trello](https://trello.com/c/FUNRgTWI/168-get-world-news-content-into-content-item)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
