### PR TITLE
Add Worldwide Organisation schema

### DIFF
--- a/app/domain/etl/edition/content/parsers/body_content.rb
+++ b/app/domain/etl/edition/content/parsers/body_content.rb
@@ -42,6 +42,7 @@ class Etl::Edition::Content::Parsers::BodyContent
       working_group
       world_location_news
       world_location_news_article
+      worldwide_organisation
     ]
   end
 end

--- a/spec/domain/etl/edition/content/body_content_spec.rb
+++ b/spec/domain/etl/edition/content/body_content_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       working_group
       world_location_news
       world_location_news_article
+      worldwide_organisation
     ].freeze
   end
 

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -101,6 +101,7 @@ private
       world_location
       world_location_news
       world_location_news_article
+      worldwide_organisation
     ]
   end
 end


### PR DESCRIPTION
This was added in https://github.com/alphagov/publishing-api/pull/2203 so needs to be a document type that content-data-api can parse.

[Trello card](https://trello.com/c/UPd8G2f5)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

