### PR TITLE
Dockerfile cleanup + enable bootsnap.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,15 @@
 .github
 Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
+features
+log
+node_modules
+script
+spec
+test
 tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,23 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
+ARG ruby_version=2.7.6
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-COPY Gemfile* .ruby-version /app/
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
-COPY . /app
+COPY . .
 
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=content-data-api
 
-WORKDIR /app
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $APP_HOME .
 
 USER app
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY . .
+RUN bootsnap precompile --gemfile .
 
 
 FROM $base_image
@@ -17,6 +18,7 @@ ENV GOVUK_APP_NAME=content-data-api
 
 WORKDIR $APP_HOME
 COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
 COPY --from=builder $APP_HOME .
 
 USER app

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "plek"
 gem "active_model_serializers"
 gem "activerecord-import"
 gem "awesome_print"
+gem "bootsnap", require: false
 gem "google-api-client"
 gem "govuk_message_queue_consumer"
 gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     brakeman (5.2.1)
     builder (3.2.4)
     bunny (2.19.0)
@@ -259,6 +261,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
+    msgpack (1.6.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     net-imap (0.3.1)
@@ -521,6 +524,7 @@ DEPENDENCIES
   awesome_print
   better_errors
   binding_of_caller
+  bootsnap
   byebug
   database_cleaner
   factory_bot_rails

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
- Use bootsnap to reduce startup resource usage spike.
- Parameterise Ruby version.
- Make better use of WORKDIR.
- Use env vars from the base image where appropriate, instead of hardcoding paths.
- Remove unnecessary use of `bundle exec`.
- Add .dockerignore.

Tested: app boots successfully with `docker run`.
