### PR TITLE
added prometheus initializer

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_prometheus_exporter"
+GovukPrometheusExporter.configure


### PR DESCRIPTION
This change is only enabled in the EKS environment. 
It is required so that the Prometheus monitoring module that's already installed as part of govuk_app_config is initialized when the container is running. 

Trello card
https://trello.com/c/bzr1KyHw/1114-investigate-current-state-of-monitoring-and-dashboards-to-understand-where-were-at-with-completing-deploy-to-integration-milesto
