### PR TITLE
Add `how_government_works` content type

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -15,6 +15,7 @@ class Etl::Edition::Content::Parsers::NoContent
       generic
       government
       homepage
+      how_government_works
       knowledge_alpha
       ministers_index
       organisations_homepage

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -23,7 +23,7 @@
     {
       "warning_type": "Unmaintained Dependency",
       "warning_code": 123,
-      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "fingerprint": "870fa4a5cfd770898e1b7a159368b4210fe366634512563f9fb1c1cbbfef1d78",
       "check_name": "EOLRuby",
       "message": "Support for Ruby 2.7.6 ends on 2023-03-31",
       "file": "Gemfile.lock",

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       facet_value
       generic
       homepage
+      how_government_works
       knowledge_alpha
       ministers_index
       organisations_homepage


### PR DESCRIPTION
This adds the new format which has been created in https://github.com/alphagov/publishing-api/pull/2303.

[Trello card](https://trello.com/c/ckwRKhIR)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

