### PR TITLE
Update Ruby version in Dockerfile to 3.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ruby_version=2.7.6
+ARG ruby_version=3.2.0
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/e5BZBWyK/3075-bump-platform-reliability-repos-ruby-versions-to-v3xx-5)

We upgraded to Ruby 3.2.0 in #1843, but neglected to update the Dockerfile. This PR brings the Dockerfile up to date.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
