### PR TITLE
Reduce batch size to smooth ETL resource usage.

### DIFF
--- a/app/domain/etl/main/metrics_processor.rb
+++ b/app/domain/etl/main/metrics_processor.rb
@@ -27,7 +27,7 @@ module Etl
         log process: :metrics, message: "about to get the Dimensions::Date"
         dimensions_date = Dimensions::Date.find_existing_or_create(date)
         log process: :metrics, message: "got the Dimensions::Date"
-        Dimensions::Edition.live.find_in_batches(batch_size: 50_000)
+        Dimensions::Edition.live.find_in_batches(batch_size: 10_000)
           .with_index do |batch, index|
           log process: :metrics, message: "processing #{batch.length} items in batch #{index}"
           values = batch.pluck(:id).map do |value|


### PR DESCRIPTION
ETL job gets OOM-killed at 2.5 GB, but the rest of the app normally sits at around 300 MB working set, so let's try to smooth this out a bit.

There doesn't seem to be anything special about the 50k batch size afaict from looking through commit history etc.

https://trello.com/c/v9XYF5EB

Tested: ran on integration, WSS peaks around 850 MB with this change.