### PR TITLE
Fix for Travel Advice pages with no summary

### DIFF
--- a/app/domain/streams/messages/multipart_message.rb
+++ b/app/domain/streams/messages/multipart_message.rb
@@ -36,11 +36,14 @@ module Streams
     def parts
       message_parts = @payload.dig("details", "parts").dup
       if doc_type == "travel_advice"
-        message_parts.prepend(
-          "slug" => base_path,
-          "title" => "Summary",
-          "body" => [@payload.dig("details", "summary").find { |x| x["content_type"] == "text/html" }],
-        )
+        summary = @payload.dig("details", "summary")&.find { |x| x["content_type"] == "text/html" }
+        unless summary.nil?
+          message_parts.prepend(
+            "slug" => base_path,
+            "title" => "Summary",
+            "body" => [summary],
+          )
+        end
       end
       message_parts
     end

--- a/spec/domain/streams/messages/multipart_message_spec.rb
+++ b/spec/domain/streams/messages/multipart_message_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Streams::Messages::MultipartMessage do
         msg
       end
 
-      it "return the attributes in an array" do
+      it "returns the attributes in an array" do
         attributes = instance.edition_attributes
         common_attributes = expected_raw_attributes(
           content_id: message.payload["content_id"],
@@ -76,45 +76,85 @@ RSpec.describe Streams::Messages::MultipartMessage do
     context "when the schema is a Travel Advice" do
       let(:message) do
         override_attributes = message_attributes.reject { |k, _| k == "document_type" }
-        msg = build(:message, :travel_advice, attributes: override_attributes)
+        msg = build(:message, :travel_advice, attributes: override_attributes, summary:)
         msg.payload["details"]["body"] = "<p>some content</p>"
         msg
       end
 
-      it "return the attributes in an array" do
-        attributes = instance.edition_attributes
-        common_attributes = expected_raw_attributes(
-          content_id: message.payload["content_id"],
-          schema_name: "travel_advice",
-          document_type: "travel_advice",
-        )
-        base_warehouse_id = "#{message.payload['content_id']}:#{message.payload['locale']}"
-        expect(attributes).to eq([
-          common_attributes.merge(
-            warehouse_item_id: base_warehouse_id,
-            child_sort_order: ["#{base_warehouse_id}:part1", "#{base_warehouse_id}:part2"],
-            document_text: "summary content",
-            title: "the-title: Summary",
-            sibling_order: 0,
-            base_path: "/base-path",
-          ),
-          common_attributes.merge(
-            warehouse_item_id: "#{base_warehouse_id}:part1",
-            document_text: "Here 1",
-            title: "the-title: Part 1",
-            sibling_order: 1,
-            base_path: "/base-path/part1",
-            parent_warehouse_id: base_warehouse_id,
-          ),
-          common_attributes.merge(
-            warehouse_item_id: "#{base_warehouse_id}:part2",
-            document_text: "be 2",
-            title: "the-title: Part 2",
-            sibling_order: 2,
-            base_path: "/base-path/part2",
-            parent_warehouse_id: base_warehouse_id,
-          ),
-        ])
+      context "when it has a summary" do
+        let(:summary) do
+          "summary content"
+        end
+
+        it "returns the attributes in an array" do
+          attributes = instance.edition_attributes
+          common_attributes = expected_raw_attributes(
+            content_id: message.payload["content_id"],
+            schema_name: "travel_advice",
+            document_type: "travel_advice",
+          )
+          base_warehouse_id = "#{message.payload['content_id']}:#{message.payload['locale']}"
+          expect(attributes).to eq([
+            common_attributes.merge(
+              warehouse_item_id: base_warehouse_id,
+              child_sort_order: ["#{base_warehouse_id}:part1", "#{base_warehouse_id}:part2"],
+              document_text: "summary content",
+              title: "the-title: Summary",
+              sibling_order: 0,
+              base_path: "/base-path",
+            ),
+            common_attributes.merge(
+              warehouse_item_id: "#{base_warehouse_id}:part1",
+              document_text: "Here 1",
+              title: "the-title: Part 1",
+              sibling_order: 1,
+              base_path: "/base-path/part1",
+              parent_warehouse_id: base_warehouse_id,
+            ),
+            common_attributes.merge(
+              warehouse_item_id: "#{base_warehouse_id}:part2",
+              document_text: "be 2",
+              title: "the-title: Part 2",
+              sibling_order: 2,
+              base_path: "/base-path/part2",
+              parent_warehouse_id: base_warehouse_id,
+            ),
+          ])
+        end
+      end
+
+      context "when it has no summary" do
+        let(:summary) do
+          nil
+        end
+
+        it "returns the attributes in an array but omits the summary section" do
+          attributes = instance.edition_attributes
+          common_attributes = expected_raw_attributes(
+            content_id: message.payload["content_id"],
+            schema_name: "travel_advice",
+            document_type: "travel_advice",
+          )
+          base_warehouse_id = "#{message.payload['content_id']}:#{message.payload['locale']}"
+          expect(attributes).to eq([
+            common_attributes.merge(
+              warehouse_item_id: base_warehouse_id,
+              child_sort_order: ["#{base_warehouse_id}:part2"],
+              document_text: "Here 1",
+              title: "the-title: Part 1",
+              sibling_order: 0,
+              base_path: "/base-path",
+            ),
+            common_attributes.merge(
+              warehouse_item_id: "#{base_warehouse_id}:part2",
+              document_text: "be 2",
+              title: "the-title: Part 2",
+              sibling_order: 1,
+              base_path: "/base-path/part2",
+              parent_warehouse_id: base_warehouse_id,
+            ),
+          ])
+        end
       end
     end
   end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -117,10 +117,12 @@ FactoryBot.define do
           result["content_id"] = content_id
           result["locale"] = locale
           result.delete("withdrawn_notice")
-          result["details"]["summary"] = [
-            "content_type" => "text/html",
-            "content" => summary,
-          ]
+          unless summary.nil?
+            result["details"]["summary"] = [
+              "content_type" => "text/html",
+              "content" => summary,
+            ]
+          end
           result["details"]["parts"] =
             [
               {


### PR DESCRIPTION
A `summary` is no longer required for Travel Advice pages[^1], but if it's not present we currently crash with ```undefined method `find' for nil:NilClass (NoMethodError)```.

[^1]: https://github.com/alphagov/publishing-api/commit/21c0711c0a894182ffcd1ed556ac2194e7365c2b

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️