### PR TITLE
Add Worldwide Offices to the list of schemas

### DIFF
--- a/app/domain/etl/edition/content/parsers/body_content.rb
+++ b/app/domain/etl/edition/content/parsers/body_content.rb
@@ -42,6 +42,7 @@ class Etl::Edition::Content::Parsers::BodyContent
       working_group
       world_location_news
       world_location_news_article
+      worldwide_office
       worldwide_organisation
     ]
   end

--- a/spec/domain/etl/edition/content/body_content_spec.rb
+++ b/spec/domain/etl/edition/content/body_content_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       working_group
       world_location_news
       world_location_news_article
+      worldwide_office
       worldwide_organisation
     ].freeze
   end


### PR DESCRIPTION
We have added a new schema for Worldwide Offices. This needs to be included in the list of schemas that can be parsed.

# Description
What are the changes? Why are you making these changes?

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [N/a] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

