### PR TITLE
Add `embassies_index` to the list of schema types

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -8,6 +8,7 @@ class Etl::Edition::Content::Parsers::NoContent
       coronavirus_landing_page
       coming_soon
       completed_transaction
+      embassies_index
       external_content
       facet
       facet_group

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       coming_soon
       completed_transaction
       coronavirus_landing_page
+      embassies_index
       external_content
       facet
       facet_group


### PR DESCRIPTION
The `embassies_index` schema was added in https://github.com/alphagov/publishing-api/pull/2354.

Therefore adding it to the list of acceptable schemas that are known about in this application.

Related to the work done in this [Trello card](https://trello.com/c/MMUcRbIT).