### PR TITLE
Fixes for govuk-docker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "pg"
 gem "rack-proxy"
 gem "rails-erd"
 gem "ruby-progressbar"
+gem "sass-rails"
 gem "scenic"
 gem "uuid"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
     minitest (5.18.0)
-    msgpack (1.6.0)
+    msgpack (1.7.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     net-imap (0.3.4)
@@ -437,6 +437,16 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     scenic (1.7.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
@@ -476,9 +486,17 @@ GEM
     spring (4.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
+    sprockets (4.2.0)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
     systemu (2.6.5)
     thor (1.2.2)
+    tilt (2.1.0)
     timecop (0.9.6)
     timeout (0.3.2)
     trailblazer-option (0.1.2)
@@ -553,6 +571,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   ruby-progressbar
+  sass-rails
   scenic
   shoulda-matchers
   simplecov

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,8 +18,6 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-require_relative "sentry"
-
 module ContentPerformanceManager
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/sentry.rb
+++ b/config/sentry.rb
@@ -1,3 +1,0 @@
-GovukError.configure do |config|
-  config.excluded_exceptions << "ApplicationJob::RetryableError"
-end


### PR DESCRIPTION
Adds sass-rails gem and removes Sentry exception that isn't needed anymore.

https://trello.com/c/915tHRoo/3206-fix-content-data-api-in-govuk-docker