### PR TITLE
Add sentry-sidekiq to track Sidekiq errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "rails-erd"
 gem "ruby-progressbar"
 gem "sass-rails"
 gem "scenic"
+gem "sentry-sidekiq"
 gem "uuid"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,6 +460,9 @@ GEM
       sentry-ruby (~> 5.9.0)
     sentry-ruby (5.9.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.9.0)
+      sentry-ruby (~> 5.9.0)
+      sidekiq (>= 3.0)
     set (1.0.3)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
@@ -574,6 +577,7 @@ DEPENDENCIES
   ruby-progressbar
   sass-rails
   scenic
+  sentry-sidekiq
   shoulda-matchers
   simplecov
   spring


### PR DESCRIPTION
# Description
The default configuration comes from GovukError in https://github.com/alphagov/govuk_app_config

Added in response to:
```
Warning: GovukError is not configured to track Sidekiq errors,
install the sentry-sidekiq gem to track them.
```

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

