### PR TITLE
Add Worldwide Corporate Information Page schema

### DIFF
--- a/app/domain/etl/edition/content/parsers/body_content.rb
+++ b/app/domain/etl/edition/content/parsers/body_content.rb
@@ -42,6 +42,7 @@ class Etl::Edition::Content::Parsers::BodyContent
       working_group
       world_location_news
       world_location_news_article
+      worldwide_corporate_information_page
       worldwide_office
       worldwide_organisation
     ]

--- a/spec/domain/etl/edition/content/body_content_spec.rb
+++ b/spec/domain/etl/edition/content/body_content_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       working_group
       world_location_news
       world_location_news_article
+      worldwide_corporate_information_page
       worldwide_office
       worldwide_organisation
     ].freeze


### PR DESCRIPTION
The Worldwide Corporate Information Page schema was added in https://github.com/alphagov/publishing-api/pull/2399.

This adds that schema type to this application.