### PR TITLE
Add Call for evidence schema

### DIFF
--- a/app/domain/etl/edition/content/parsers/body_content.rb
+++ b/app/domain/etl/edition/content/parsers/body_content.rb
@@ -15,6 +15,7 @@ class Etl::Edition::Content::Parsers::BodyContent
     %w[
       answer
       calendar
+      call_for_evidence
       case_study
       consultation
       corporate_information_page

--- a/spec/domain/etl/edition/content/body_content_spec.rb
+++ b/spec/domain/etl/edition/content/body_content_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Etl::Edition::Content::Parser do
     %w[
       answer
       calendar
+      call_for_evidence
       case_study
       consultation
       corporate_information_page


### PR DESCRIPTION
The Worldwide Corporate Information Page schema was added in https://github.com/alphagov/publishing-api/pull/2391

This adds that schema type to this application.