### PR TITLE
Fix broken spec in `domain/finders/content_spec.rb`

### DIFF
--- a/spec/domain/finders/content_spec.rb
+++ b/spec/domain/finders/content_spec.rb
@@ -148,14 +148,14 @@ RSpec.describe Finders::Content do
     end
 
     it "returns aggregations for a specific month" do
-      august2022 = Date.new(2022, 8, 1)
+      date = this_month_date - 6.months
+      month_name = Date::MONTHNAMES[date.month].downcase
       create :metric, edition: edition1, date: this_month_date, upviews: 15, useful_yes: 1, useful_no: 4, searches: 10
-      create :metric, edition: edition1, date: august2022, upviews: 20, useful_yes: 4, useful_no: 1, searches: 1
-      create :metric, edition: edition2, date: august2022, upviews: 10, useful_yes: 4, useful_no: 1, searches: 11
+      create :metric, edition: edition1, date:, upviews: 20, useful_yes: 4, useful_no: 1, searches: 1
+      create :metric, edition: edition2, date:, upviews: 10, useful_yes: 4, useful_no: 1, searches: 11
 
       recalculate_aggregations!
-
-      response = described_class.call(filter: filter.merge(date_range: "august-2022"))
+      response = described_class.call(filter: filter.merge(date_range: "#{month_name}-#{date.year}"))
 
       expect(response[:results]).to contain_exactly(
         hash_including(upviews: 20, searches: 1, satisfaction: 0.8),


### PR DESCRIPTION
This spec previously hardcoded August 2022 as the date to test. However, the `recalculate_aggregations!` helper method only refreshes the last year worth of monthly aggregations, meaning that this spec broke in August 2023.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️