### PR TITLE
Add Google Cloud BigQuery gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "activerecord-import"
 gem "awesome_print"
 gem "bootsnap", require: false
 gem "google-api-client"
+gem "google-cloud-bigquery"
 gem "govuk_message_queue_consumer"
 gem "httparty"
 gem "jbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,8 @@ GEM
     google-api-client (0.53.0)
       google-apis-core (~> 0.1)
       google-apis-generator (~> 0.1)
+    google-apis-bigquery_v2 (0.33.0)
+      google-apis-core (>= 0.4, < 2.a)
     google-apis-core (0.4.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
@@ -173,6 +175,18 @@ GEM
       google-apis-core (>= 0.4, < 2.a)
       google-apis-discovery_v1 (~> 0.5)
       thor (>= 0.20, < 2.a)
+    google-cloud-bigquery (1.45.0)
+      concurrent-ruby (~> 1.0)
+      google-apis-bigquery_v2 (~> 0.1)
+      google-cloud-core (~> 1.6)
+      googleauth (>= 0.16.2, < 2.a)
+      mini_mime (~> 1.0)
+    google-cloud-core (1.6.0)
+      google-cloud-env (~> 1.0)
+      google-cloud-errors (~> 1.0)
+    google-cloud-env (1.6.0)
+      faraday (>= 0.17.3, < 3.0)
+    google-cloud-errors (1.3.1)
     google-protobuf (3.24.4)
     googleapis-common-protos-types (1.9.0)
       google-protobuf (~> 3.18)
@@ -758,6 +772,7 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   google-api-client
+  google-cloud-bigquery
   govuk_app_config
   govuk_message_queue_consumer
   govuk_schemas


### PR DESCRIPTION
# Description
Google is dropping their support for UA in favour of GA4.
As part of this migration, we will have to use BigQuery to get some of our metrics as they are not supported in GA4's API.

Trello card: https://trello.com/c/fXrYfzQ4/3305-figure-out-first-steps-for-content-data-ga4-migration


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

