### PR TITLE
Migrate views navigation metrics to ga4 bq

### DIFF
--- a/app/domain/etl/aggregations/monthly.rb
+++ b/app/domain/etl/aggregations/monthly.rb
@@ -48,13 +48,11 @@ private
         dimensions_edition_id,
         pviews,
         upviews,
-        entrances,
         searches,
         feedex,
         satisfaction,
         useful_yes,
         useful_no,
-        exits,
         updated_at,
         created_at
       )
@@ -62,7 +60,6 @@ private
         max(dimensions_edition_id),
         sum(pviews),
         sum(upviews),
-        sum(entrances),
         sum(searches),
         sum(feedex),
         CASE
@@ -71,7 +68,6 @@ private
         END AS satisfaction,
         sum(useful_yes),
         sum(useful_no),
-        sum(exits),
         now(),
         now()
       FROM facts_metrics

--- a/app/domain/etl/ga/bigquery.rb
+++ b/app/domain/etl/ga/bigquery.rb
@@ -1,0 +1,25 @@
+require "google/cloud/bigquery"
+require "googleauth"
+
+class Etl::GA::Bigquery
+  include Google::Auth
+
+  def self.build
+    new.build
+  end
+
+  def build
+    credentials = {
+      "client_email" => ENV["BIGQUERY_CLIENT_EMAIL"],
+      "private_key" => ENV["BIGQUERY_PRIVATE_KEY"],
+    }
+
+    Google::Cloud::Bigquery.new(
+      project_id: ENV["BIGQUERY_PROJECT"],
+      credentials: Google::Auth::ServiceAccountCredentials.make_creds(
+        json_key_io: StringIO.new(credentials.to_json),
+        scope: ["https://www.googleapis.com/auth/bigquery"],
+      ),
+    )
+  end
+end

--- a/app/domain/etl/ga/views_and_navigation_processor.rb
+++ b/app/domain/etl/ga/views_and_navigation_processor.rb
@@ -46,18 +46,10 @@ private
     <<~SQL
       UPDATE facts_metrics
       SET upviews = s.upviews,
-          pviews = s.pviews,
-          entrances = s.entrances,
-          exits = s.exits,
-          bounces = s.bounces,
-          page_time = s.page_time
+          pviews = s.pviews
       FROM (
         SELECT pviews,
                upviews,
-               entrances,
-               exits,
-               bounces,
-               page_time,
                dimensions_editions.id
         FROM events_gas, dimensions_editions
         WHERE page_path = LOWER(base_path)

--- a/app/domain/etl/ga/views_and_navigation_service.rb
+++ b/app/domain/etl/ga/views_and_navigation_service.rb
@@ -8,35 +8,20 @@ class Etl::GA::ViewsAndNavigationService
   def find_in_batches(date:, batch_size: 10_000, &block)
     fetch_data(date:)
       .lazy
-      .map(&:to_h)
-      .flat_map(&method(:extract_rows))
-      .map(&method(:extract_dimensions_and_metrics))
+      .map(&:stringify_keys)
       .map(&method(:append_data_labels))
       .reject(&method(:invalid_record?))
-      .map { |hash| set_date(hash, date) }
       .each_slice(batch_size, &block)
   end
 
   def client
-    @client ||= Etl::GA::Client.build
+    @client ||= Etl::GA::Bigquery.build
   end
 
 private
 
-  def set_date(hash, date)
-    hash["date"] = date.strftime("%F")
-    hash
-  end
-
-  def append_data_labels(values)
-    page_path, pviews, upviews = *values
-
-    {
-      "page_path" => page_path,
-      "pviews" => pviews,
-      "upviews" => upviews,
-      "process_name" => "views",
-    }
+  def append_data_labels(hash)
+    hash.merge("process_name" => "views")
   end
 
   def invalid_record?(data)
@@ -45,48 +30,24 @@ private
     true
   end
 
-  def extract_dimensions_and_metrics(row)
-    dimensions = row.fetch(:dimensions)
-    metrics = row.fetch(:metrics).flat_map do |metric|
-      metric.fetch(:values).map(&:to_i)
-    end
-
-    dimensions + metrics
-  end
-
-  def extract_rows(report)
-    report.fetch(:rows)
-  end
-
   def fetch_data(date:)
-    @fetch_data ||= client.fetch_all(items: :data) do |page_token, service|
-      service
-        .batch_get_reports(
-          Google::Apis::AnalyticsreportingV4::GetReportsRequest.new(
-            report_requests: [build_request(date:).merge(page_token:)],
-          ),
-        )
-        .reports
-        .first
-    end
-  end
+    @fetch_data ||= client
+    @date = date.strftime("%Y-%m-%d")
 
-  def build_request(date:)
-    {
-      date_ranges: [
-        { start_date: date.to_fs("%Y-%m-%d"), end_date: date.to_fs("%Y-%m-%d") },
-      ],
-      dimensions: [
-        { name: "ga:pagePath" },
-      ],
-      hide_totals: true,
-      hide_value_ranges: true,
-      metrics: [
-        { expression: "ga:pageviews" },
-        { expression: "ga:uniquePageviews" },
-      ],
-      page_size: 10_000,
-      view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
-    }
+    query = <<~SQL
+      WITH CTE1 AS (
+        SELECT *
+        FROM `govuk-content-data.dataform.GA4 dataform`
+        WHERE the_date = @date
+      )
+      SELECT
+        cleaned_page_location AS page_path,
+        unique_page_views AS upviews,
+        total_page_views AS pviews,
+        the_date AS date,
+      FROM CTE1
+    SQL
+
+    @fetch_data.query(query, params: { date: @date }).all
   end
 end

--- a/app/domain/etl/ga/views_and_navigation_service.rb
+++ b/app/domain/etl/ga/views_and_navigation_service.rb
@@ -29,17 +29,13 @@ private
   end
 
   def append_data_labels(values)
-    page_path, pviews, upviews, entrances, exits, bounces, page_time = *values
+    page_path, pviews, upviews = *values
 
     {
       "page_path" => page_path,
       "pviews" => pviews,
       "upviews" => upviews,
       "process_name" => "views",
-      "entrances" => entrances,
-      "exits" => exits,
-      "bounces" => bounces,
-      "page_time" => page_time,
     }
   end
 
@@ -88,11 +84,6 @@ private
       metrics: [
         { expression: "ga:pageviews" },
         { expression: "ga:uniquePageviews" },
-        { expression: "ga:entrances" },
-        { expression: "ga:exits" },
-        { expression: "ga:avgTimeOnPage" },
-        { expression: "ga:bounces" },
-        { expression: "ga:timeOnPage" },
       ],
       page_size: 10_000,
       view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -27,14 +27,6 @@ daily:
     description: "Number of times a user searches for something else on GOV.UK from the page"
     source: 'Google Analytics'
 
-  - name: 'entrances'
-    description: "Number of session that began with this page"
-    source: 'Google Analytics'
-
-  - name: 'exits'
-    description: "Number of session that ended with this page"
-    source: 'Google Analytics'
-
 edition:
   - name: 'pdf_count'
     description: "Number of .pdf attachments"

--- a/spec/domain/etl/ga/bigquery_spec.rb
+++ b/spec/domain/etl/ga/bigquery_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Etl::GA::Bigquery do
+  describe "Connecting to the Google Cloud BigQuery API" do
+    before do
+      stub_request(:post, "https://www.googleapis.com/oauth2/v4/token")
+      .to_return(status: 200, body: "{}", headers: { "Content-Type" => "application/json" })
+
+      ENV["BIGQUERY_PROJECT"] = "bigquery-project-123"
+      ENV["BIGQUERY_CLIENT_EMAIL"] = "test@test.com"
+      ENV["BIGQUERY_PRIVATE_KEY"] = "key"
+
+      allow(OpenSSL::PKey::RSA).to receive(:new).and_return("key")
+    end
+
+    context "api client" do
+      subject { Etl::GA::Bigquery.new.build }
+
+      it "is an instance of Google::Cloud::Bigquery::Project" do
+        expect(subject).to be_kind_of(Google::Cloud::Bigquery::Project)
+      end
+    end
+
+    context "when setting up authorization" do
+      subject { Etl::GA::Bigquery.new.build }
+
+      it "uses the given client email from the JSON contents" do
+        expect(subject.service.credentials.issuer).to eq("test@test.com")
+      end
+
+      it "uses the given private key from the JSON contents" do
+        expect(subject.service.credentials.signing_key).to eq("key")
+      end
+
+      it "uses the BigQuery scope" do
+        expect(subject.service.credentials.scope).to include("https://www.googleapis.com/auth/bigquery")
+      end
+
+      it "raises an error if the project_id is not set" do
+        ENV["BIGQUERY_PROJECT"] = ""
+
+        expect { Etl::GA::Bigquery.new.build }.to raise_error(ArgumentError, "project_id is missing")
+      end
+    end
+  end
+end

--- a/spec/domain/etl/ga/concerns/transform_path_spec.rb
+++ b/spec/domain/etl/ga/concerns/transform_path_spec.rb
@@ -23,15 +23,11 @@ RSpec.describe Etl::GA::Concerns::TransformPath do
         :ga_event,
         :with_views,
         page_path: "/https://www.gov.uk/topics",
-        bounces: 1,
         upviews: 1,
         pviews: 1,
         useful_no: 1,
         useful_yes: 1,
         searches: 1,
-        entrances: 1,
-        exits: 1,
-        page_time: 1,
       )
     end
 
@@ -40,20 +36,16 @@ RSpec.describe Etl::GA::Concerns::TransformPath do
         :ga_event,
         :with_views,
         page_path: "/topics",
-        bounces: 1000,
         upviews: 100,
         pviews: 200,
         useful_no: 300,
         useful_yes: 400,
         searches: 500,
-        entrances: 600,
-        exits: 700,
-        page_time: 1000,
       )
     end
 
     it "returns the correct number of metrics" do
-      names_to_exclude = %w[id bounces date page_path updated_at created_at process_name page_time]
+      names_to_exclude = %w[id bounces date page_path updated_at created_at process_name page_time entrances exits]
       event_attributes = event2.attribute_names.reject { |name| names_to_exclude.include?(name) }
 
       subject.format_events_with_invalid_prefix
@@ -66,13 +58,13 @@ RSpec.describe Etl::GA::Concerns::TransformPath do
     it "explicitly ignores bounces" do
       subject.format_events_with_invalid_prefix
 
-      expect(event2.reload.bounces).to eq(1)
+      expect(event2.reload.bounces).to eq(0)
     end
 
     it "explicitly ignores page_time" do
       subject.format_events_with_invalid_prefix
 
-      expect(event2.reload.page_time).to eq(1)
+      expect(event2.reload.page_time).to eq(0)
     end
 
     it "updates events with their combined upviews" do
@@ -103,18 +95,6 @@ RSpec.describe Etl::GA::Concerns::TransformPath do
       subject.format_events_with_invalid_prefix
 
       expect(event2.reload.searches).to eq 501
-    end
-
-    it "updates events with their combines entrances" do
-      subject.format_events_with_invalid_prefix
-
-      expect(event2.reload.entrances).to eq 601
-    end
-
-    it "updates events with their combines exits" do
-      subject.format_events_with_invalid_prefix
-
-      expect(event2.reload.exits).to eq 701
     end
 
     it "deletes the duplicated event" do

--- a/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
@@ -15,9 +15,7 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
     before { allow(Etl::GA::ViewsAndNavigationService).to receive(:find_in_batches).and_yield(ga_response) }
 
     it "update the facts with the GA metrics" do
-      fact1 = create :metric,
-                     edition: edition1,
-                     date: "2018-02-20"
+      fact1 = create :metric, edition: edition1, date: "2018-02-20"
       fact2 = create :metric, edition: edition2, date: "2018-02-20"
 
       described_class.process(date:)
@@ -64,6 +62,58 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
         described_class.process(date:)
 
         expect(fact1.reload).to have_attributes(pviews: 1, upviews: 1)
+      end
+    end
+  end
+
+  context "When the GA path contains the gov.uk prefix" do
+    before { allow(Etl::GA::ViewsAndNavigationService).to receive(:find_in_batches).and_yield(ga_response_with_govuk_prefix) }
+
+    context "when an event does not already exist with the same page_path" do
+      it "updates the fact with the GA metrics" do
+        fact1 = create :metric, edition: edition1, date: "2018-02-20"
+
+        described_class.process(date:)
+
+        expect(fact1.reload).to have_attributes(pviews: 1, upviews: 1)
+      end
+    end
+
+    context "when an event already exists with the same page_path" do
+      before do
+        create(:ga_event, :with_views, date: "2018-02-20", page_path: "/path1")
+      end
+
+      it "updates the fact with the aggregated GA metrics" do
+        fact1 = create :metric, edition: edition1, date: "2018-02-20"
+
+        described_class.process(date:)
+
+        expect(fact1.reload).to have_attributes(pviews: 11, upviews: 6)
+      end
+
+      it "does not update metrics for other days" do
+        fact1 = create :metric, edition: edition1, date: "2018-02-20", pviews: 20, upviews: 10
+
+        day_before = date - 1
+        described_class.process(date: day_before)
+
+        expect(fact1.reload).to have_attributes(pviews: 20, upviews: 10)
+      end
+
+      it "does not update metrics for other items" do
+        edition = create :edition, base_path: "/non-matching-path", date: "2018-02-20"
+        fact = create :metric, edition:, date: "2018-02-20", pviews: 99, upviews: 90
+
+        described_class.process(date:)
+
+        expect(fact.reload).to have_attributes(pviews: 99, upviews: 90)
+      end
+
+      it "deletes events after updating facts metrics" do
+        described_class.process(date:)
+
+        expect(Events::GA.count).to eq(0)
       end
     end
   end

--- a/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_processor_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Etl::GA::ViewsAndNavigationProcessor do
 
       described_class.process(date:)
 
-      expect(fact1.reload).to have_attributes(pviews: 1, upviews: 1, entrances: 10, exits: 5, bounces: 31, page_time: 20)
-      expect(fact2.reload).to have_attributes(pviews: 2, upviews: 2, entrances: 20, exits: 10, bounces: 50, page_time: 23)
+      expect(fact1.reload).to have_attributes(pviews: 1, upviews: 1)
+      expect(fact2.reload).to have_attributes(pviews: 2, upviews: 2)
     end
 
     it "does not update metrics for other days" do
@@ -80,10 +80,6 @@ private
         "upviews" => 1,
         "date" => "2018-02-20",
         "process_name" => "views",
-        "entrances" => 10,
-        "exits" => 5,
-        "bounces" => 31,
-        "page_time" => 20,
       },
       {
         "page_path" => "/path2",
@@ -91,10 +87,6 @@ private
         "upviews" => 2,
         "date" => "2018-02-20",
         "process_name" => "views",
-        "entrances" => 20,
-        "exits" => 10,
-        "bounces" => 50,
-        "page_time" => 23,
       },
     ]
   end
@@ -107,10 +99,6 @@ private
         "upviews" => 1,
         "date" => "2018-02-20",
         "process_name" => "views",
-        "entrances" => 10,
-        "exits" => 5,
-        "bounces" => 66,
-        "page_time" => 86,
       },
       {
         "page_path" => "/path2",
@@ -118,10 +106,6 @@ private
         "upviews" => 2,
         "date" => "2018-02-20",
         "process_name" => "views",
-        "entrances" => 20,
-        "exits" => 10,
-        "bounces" => 15,
-        "page_time" => 63,
       },
     ]
   end

--- a/spec/domain/etl/ga/views_and_navigation_service_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_service_spec.rb
@@ -1,55 +1,44 @@
-require "google/apis/analyticsreporting_v4"
-
 RSpec.describe Etl::GA::ViewsAndNavigationService do
-  include GoogleAnalyticsRequests
-
   subject { Etl::GA::ViewsAndNavigationService }
 
-  let(:google_client) { instance_double(Google::Apis::AnalyticsreportingV4::AnalyticsReportingService) }
-  before { expect(Etl::GA::Client).to receive(:build).and_return(google_client) }
+  let(:google_client) { instance_double(Google::Cloud::Bigquery::Project) }
+  let(:results) { instance_double(Google::Cloud::Bigquery::Data) }
+
+  before do
+    allow(Etl::GA::Bigquery).to receive(:build).and_return(google_client)
+    allow(google_client).to receive(:query).and_return(results)
+
+    allow(results).to receive(:all).and_return([
+      { "page_path" => "/foo", "pviews" => 1, "upviews" => 1, "date" => "2018-02-20" },
+      { "page_path" => "/bar", "pviews" => 2, "upviews" => 2, "date" => "2018-02-20" },
+      { "page_path" => "/cool", "pviews" => 3, "upviews" => 3, "date" => "2018-02-20" },
+    ])
+  end
 
   describe "#find_in_batches" do
     let(:date) { Date.new(2018, 2, 20) }
 
     context "when #find_in_batches is called with a block" do
-      before do
-        allow(google_client).to receive(:fetch_all) do
-          [
-            build_report_data(
-              build_report_row(dimensions: %w[/foo], metrics: %w[1 1 1 1]),
-            ),
-            build_report_data(
-              build_report_row(dimensions: %w[/bar], metrics: %w[2 2 2 2]),
-            ),
-            build_report_data(
-              build_report_row(dimensions: %w[/cool], metrics: %w[3 3 3]),
-            ),
-          ]
-        end
-      end
-
       it "yields successive report data" do
         arg1 = [
-          a_hash_including(
-            "page_path" => "/foo",
-            "pviews" => 1,
-            "upviews" => 1,
-            "date" => "2018-02-20",
-          ),
-          a_hash_including(
-            "page_path" => "/bar",
-            "pviews" => 2,
-            "upviews" => 2,
-            "date" => "2018-02-20",
-          ),
+          a_hash_including("page_path" => "/foo", "pviews" => 1, "upviews" => 1, "date" => "2018-02-20"),
+          a_hash_including("page_path" => "/bar", "pviews" => 2, "upviews" => 2, "date" => "2018-02-20"),
         ]
         arg2 = [
-          a_hash_including(
-            "page_path" => "/cool",
-            "pviews" => 3,
-            "upviews" => 3,
-            "date" => "2018-02-20",
-          ),
+          a_hash_including("page_path" => "/cool", "pviews" => 3, "upviews" => 3, "date" => "2018-02-20"),
+        ]
+
+        expect { |probe| subject.find_in_batches(date:, batch_size: 2, &probe) }
+          .to yield_successive_args(arg1, arg2)
+      end
+
+      it "yields successive report data including the process name" do
+        arg1 = [
+          a_hash_including("process_name" => "views"),
+          a_hash_including("process_name" => "views"),
+        ]
+        arg2 = [
+          a_hash_including("process_name" => "views"),
         ]
 
         expect { |probe| subject.find_in_batches(date:, batch_size: 2, &probe) }
@@ -59,27 +48,16 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
 
     context "when report data has page path with long query strings" do
       it "should ignore page" do
-        allow(google_client).to receive(:fetch_all) do
+        allow(results).to receive(:all) do
           [
-            build_report_data(
-              build_report_row(dimensions: %w[/foo], metrics: %w[1 1 1]),
-            ),
-            build_report_data(
-              build_report_row(dimensions: [path_with_long_query], metrics: %w[1 1 1 1]),
-            ),
-            build_report_data(
-              build_report_row(dimensions: [long_path], metrics: %w[1 1 1 1]),
-            ),
+            { "page_path" => "/foo", "pviews" => 1, "upviews" => 1, "date" => "2018-02-20" },
+            { "page_path" => path_with_long_query, "pviews" => 2, "upviews" => 2, "date" => "2018-02-20" },
+            { "page_path" => long_path, "pviews" => 3, "upviews" => 3, "date" => "2018-02-20" },
           ]
         end
 
         arg = [
-          a_hash_including(
-            "page_path" => "/foo",
-            "pviews" => 1,
-            "upviews" => 1,
-            "date" => "2018-02-20",
-          ),
+          a_hash_including("page_path" => "/foo", "pviews" => 1, "upviews" => 1, "date" => "2018-02-20"),
         ]
 
         expect { |probe| subject.find_in_batches(date:, batch_size: 1, &probe) }
@@ -89,24 +67,15 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
 
     context "when report data has page path with an invalid URI" do
       it "should ignore page" do
-        allow(google_client).to receive(:fetch_all) do
+        allow(results).to receive(:all) do
           [
-            build_report_data(
-              build_report_row(dimensions: %w[/foo], metrics: %w[1 1 1 1]),
-            ),
-            build_report_data(
-              build_report_row(dimensions: [path_with_invalid_uri], metrics: %w[1 1 1 1]),
-            ),
+            { "page_path" => "/foo", "pviews" => 1, "upviews" => 1, "date" => "2018-02-20" },
+            { "page_path" => path_with_invalid_uri, "pviews" => 2, "upviews" => 2, "date" => "2018-02-20" },
           ]
         end
 
         arg = [
-          a_hash_including(
-            "page_path" => "/foo",
-            "pviews" => 1,
-            "upviews" => 1,
-            "date" => "2018-02-20",
-          ),
+          a_hash_including("page_path" => "/foo", "pviews" => 1, "upviews" => 1, "date" => "2018-02-20"),
         ]
 
         expect { |probe| subject.find_in_batches(date:, batch_size: 1, &probe) }

--- a/spec/domain/etl/ga/views_and_navigation_service_spec.rb
+++ b/spec/domain/etl/ga/views_and_navigation_service_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
         allow(google_client).to receive(:fetch_all) do
           [
             build_report_data(
-              build_report_row(dimensions: %w[/foo], metrics: %w[1 1 1 1 1 1 1 1]),
+              build_report_row(dimensions: %w[/foo], metrics: %w[1 1 1 1]),
             ),
             build_report_data(
-              build_report_row(dimensions: %w[/bar], metrics: %w[2 2 2 2 2 2 2 2]),
+              build_report_row(dimensions: %w[/bar], metrics: %w[2 2 2 2]),
             ),
             build_report_data(
-              build_report_row(dimensions: %w[/cool], metrics: %w[3 3 3 3 3 3 3 3]),
+              build_report_row(dimensions: %w[/cool], metrics: %w[3 3 3]),
             ),
           ]
         end
@@ -34,20 +34,12 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
             "page_path" => "/foo",
             "pviews" => 1,
             "upviews" => 1,
-            "entrances" => 1,
-            "exits" => 1,
-            "bounces" => 1,
-            "page_time" => 1,
             "date" => "2018-02-20",
           ),
           a_hash_including(
             "page_path" => "/bar",
             "pviews" => 2,
             "upviews" => 2,
-            "entrances" => 2,
-            "exits" => 2,
-            "bounces" => 2,
-            "page_time" => 2,
             "date" => "2018-02-20",
           ),
         ]
@@ -56,10 +48,6 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
             "page_path" => "/cool",
             "pviews" => 3,
             "upviews" => 3,
-            "entrances" => 3,
-            "exits" => 3,
-            "bounces" => 3,
-            "page_time" => 3,
             "date" => "2018-02-20",
           ),
         ]
@@ -74,13 +62,13 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
         allow(google_client).to receive(:fetch_all) do
           [
             build_report_data(
-              build_report_row(dimensions: %w[/foo], metrics: %w[1 1 1 1 1 1 1 1]),
+              build_report_row(dimensions: %w[/foo], metrics: %w[1 1 1]),
             ),
             build_report_data(
-              build_report_row(dimensions: [path_with_long_query], metrics: %w[1 1 1 1 1 1 1 1]),
+              build_report_row(dimensions: [path_with_long_query], metrics: %w[1 1 1 1]),
             ),
             build_report_data(
-              build_report_row(dimensions: [long_path], metrics: %w[1 1 1 1 1 1 1 1]),
+              build_report_row(dimensions: [long_path], metrics: %w[1 1 1 1]),
             ),
           ]
         end
@@ -90,10 +78,6 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
             "page_path" => "/foo",
             "pviews" => 1,
             "upviews" => 1,
-            "entrances" => 1,
-            "exits" => 1,
-            "bounces" => 1,
-            "page_time" => 1,
             "date" => "2018-02-20",
           ),
         ]
@@ -108,10 +92,10 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
         allow(google_client).to receive(:fetch_all) do
           [
             build_report_data(
-              build_report_row(dimensions: %w[/foo], metrics: %w[1 1 1 1 1 1 1 1]),
+              build_report_row(dimensions: %w[/foo], metrics: %w[1 1 1 1]),
             ),
             build_report_data(
-              build_report_row(dimensions: [path_with_invalid_uri], metrics: %w[1 1 1 1 1 1 1 1]),
+              build_report_row(dimensions: [path_with_invalid_uri], metrics: %w[1 1 1 1]),
             ),
           ]
         end
@@ -121,10 +105,6 @@ RSpec.describe Etl::GA::ViewsAndNavigationService do
             "page_path" => "/foo",
             "pviews" => 1,
             "upviews" => 1,
-            "entrances" => 1,
-            "exits" => 1,
-            "bounces" => 1,
-            "page_time" => 1,
             "date" => "2018-02-20",
           ),
         ]

--- a/spec/domain/finders/find_series_spec.rb
+++ b/spec/domain/finders/find_series_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Finders::FindSeries do
     it "returns a series of all metrics" do
       create :metric, date: Time.zone.today, pviews: 1
 
-      expect(described_class.new.run.length).to eq(16)
+      expect(described_class.new.run.length).to eq(14)
     end
   end
 

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -11,8 +11,6 @@ EDITION_METRICS =
 
 DAILY_METRICS =
   %w[
-    entrances
-    exits
     feedex
     useful_no
     useful_yes
@@ -25,8 +23,7 @@ RSpec.describe Metric do
   describe ".find_all" do
     it "returns a list of all metrics" do
       metrics = Metric.find_all
-
-      expect(metrics.length).to eq(16)
+      expect(metrics.length).to eq(14)
       a_metric = metrics.first
       expect(a_metric).to be_an_instance_of(Metric)
     end
@@ -36,7 +33,7 @@ RSpec.describe Metric do
     it "returns a list of all metrics" do
       metric_names = Metric.find_all_names
 
-      expect(metric_names.length).to eq(16)
+      expect(metric_names.length).to eq(14)
       a_metric = metric_names.first
       expect(a_metric).to eq("chars")
     end


### PR DESCRIPTION
Google are sunsetting their Universal Analytics (UA) product in July 2024 and is being replaced by Google Analytics 4 (GA4).

Content Data uses three services to obtain various Google metrics on [GOV.UK](http://gov.uk/) pages:
- Views & Navigation
- Internal Search
- User Feedback

This PR migrates the Views & Navigation metrics from using UA to GA4/BigQuery. It also includes stopping the collection of some metrics as they are are not actively available to the user (and we will not be collecting in GA4).
We expect GA4 to collect more fine-tuned metrics and therefore the numbers will be higher than what is available in UA.
See individual commits for more detail.

This has been tested on Integration - see screenshots below.

Page views for gov.uk/sign-in-universal-credit ([Before](https://content-data.publishing.service.gov.uk/metrics/sign-in-universal-credit?date_range=past-30-days)):

<img width="992" alt="Screenshot 2024-01-15 at 14 50 07" src="https://github.com/alphagov/content-data-api/assets/19667619/c72afd4b-ecc4-4a8c-874d-4a7153a5b032">

Page views for gov.uk/sign-in-universal-credit ([After](https://content-data.integration.publishing.service.gov.uk/metrics/sign-in-universal-credit?date_range=past-30-days)):

<img width="998" alt="Screenshot 2024-01-15 at 14 50 39" src="https://github.com/alphagov/content-data-api/assets/19667619/db866d04-dacd-4fd2-b7fe-7ea89365a2f1">

Unique page views for gov.uk/sign-in-universal-credit ([Before](https://content-data.publishing.service.gov.uk/metrics/sign-in-universal-credit?date_range=past-30-days)):

<img width="1003" alt="Screenshot 2024-01-15 at 14 48 51" src="https://github.com/alphagov/content-data-api/assets/19667619/1f6c73b2-31cf-409a-a75b-12425098ad4f">

Unique page views for gov.uk/sign-in-universal-credit ([After](https://content-data.integration.publishing.service.gov.uk/metrics/sign-in-universal-credit?date_range=past-30-days)):

<img width="1001" alt="Screenshot 2024-01-15 at 14 49 36" src="https://github.com/alphagov/content-data-api/assets/19667619/8bc295b9-6275-4005-9b56-8ede092c8305">

Trello card: https://trello.com/c/c4jN6yxT/3330-migrate-ua-metrics-for-views-navigation-to-bigquery-in-content-data-api-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


