### PR TITLE
Update the GA4 data location for Views & Navigation

### DIFF
--- a/app/domain/etl/ga/views_and_navigation_service.rb
+++ b/app/domain/etl/ga/views_and_navigation_service.rb
@@ -37,7 +37,7 @@ private
     query = <<~SQL
       WITH CTE1 AS (
         SELECT *
-        FROM `govuk-content-data.dataform.GA4 dataform`
+        FROM `govuk-content-data.ga4.GA4 dataform`
         WHERE the_date = @date
       )
       SELECT


### PR DESCRIPTION
The location was changed as a knock on effect of improving the code space in Google's BigQuery Studio. The code is updated via a trigger, and the location of the outputs needed a restructure as a result of this.

This has been manually tested on Integration by running the `etl:repopulateviews` rake task.

Related PR - https://github.com/alphagov/content-data-api/pull/2005

Trello card - https://trello.com/c/c4jN6yxT/3330-migrate-ua-metrics-for-views-navigation-to-bigquery-in-content-data-api-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

