### PR TITLE
Use BigQuery for User Feedback analytics

### DIFF
--- a/app/domain/etl/ga/user_feedback_service.rb
+++ b/app/domain/etl/ga/user_feedback_service.rb
@@ -6,94 +6,39 @@ class Etl::GA::UserFeedbackService
   def find_in_batches(date:, batch_size: 10_000, &block)
     fetch_data(date:)
       .lazy
-      .map(&:to_h)
-      .flat_map(&method(:extract_rows))
-      .map(&method(:extract_dimensions_and_metrics))
+      .map(&:stringify_keys)
       .map(&method(:append_labels))
-      .map { |hash| set_date(hash, date) }
-      .group_by { |h| h["page_path"] }
-      .map { |h| format_data(h) }
       .each_slice(batch_size, &block)
   end
 
   def client
-    @client ||= Etl::GA::Client.build
+    @client ||= Etl::GA::Bigquery.build
   end
 
 private
 
-  def set_date(hash, date)
-    hash["date"] = date.strftime("%F")
-    hash
-  end
-
-  def append_labels(values)
-    page_path, event_action, value = *values
-    {
-      "page_path" => page_path,
-      event_action.to_s => value,
-    }
-  end
-
-  def extract_dimensions_and_metrics(row)
-    dimensions = row.fetch(:dimensions)
-    metrics = row.fetch(:metrics).flat_map do |metric|
-      metric.fetch(:values).map(&:to_i)
-    end
-
-    dimensions + metrics
-  end
-
-  def extract_rows(report)
-    report.fetch(:rows)
+  def append_labels(hash)
+    hash.merge("process_name" => "user_feedback")
   end
 
   def fetch_data(date:)
-    @fetch_data ||= client.fetch_all(items: :data) do |page_token, service|
-      service
-        .batch_get_reports(
-          Google::Apis::AnalyticsreportingV4::GetReportsRequest.new(
-            report_requests: [build_request(date:).merge(page_token:)],
-            use_resource_quotas: true,
-          ),
-        )
-        .reports
-        .first
-    end
-  end
+    @fetch_data = client
+    @date = date.strftime("%Y-%m-%d")
 
-  def build_request(date:)
-    {
-      date_ranges: [
-        { start_date: date.to_fs("%Y-%m-%d"), end_date: date.to_fs("%Y-%m-%d") },
-      ],
-      dimensions: [
-        { name: "ga:pagePath" },
-        { name: "ga:eventAction" },
-      ],
-      hide_totals: true,
-      hide_value_ranges: true,
-      metrics: [
-        { expression: "ga:uniqueDimensionCombinations" },
-      ],
-      filters_expression: "ga:eventAction==ffNoClick,ga:eventAction==ffYesClick",
-      page_size: 10_000,
-      view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
-    }
-  end
+    query = <<~SQL
+      WITH CTE1 AS (
+        SELECT *
+        FROM `govuk-content-data.ga4.GA4 dataform`
+        WHERE the_date = @date
+      )
+      SELECT
+        cleaned_page_location AS page_path,
+        useful_yes,
+        useful_no,
+        the_date AS date,
+      FROM CTE1
+    SQL
 
-  def format_data(hash)
-    key, value = *hash
-    no_action = value.find { |v| v["ffNoClick"] }
-    yes_action = value.find { |v| v["ffYesClick"] }
-    yes = yes_action ? yes_action["ffYesClick"] : 0
-    no = no_action ? no_action["ffNoClick"] : 0
-    {
-      "page_path" => key,
-      "useful_yes" => yes,
-      "useful_no" => no,
-      "date" => value.first["date"],
-      "process_name" => "user_feedback",
-    }
+    @fetch_data.query(query, params: { date: @date }).all
   end
 end


### PR DESCRIPTION
Instead of fetching data from UA we now use the BigQuery API which
allows us to query the table for the specific metrics we need. It
already returns the information we need in the correct format and
reduces the amount of work required post query.

https://trello.com/c/6OkkMnm0/3411-5-migrate-ua-metrics-for-user-feedback-to-bigquery-in-content-data-api