### PR TITLE
Use BigQuery/GA4 for Internal Search metrics

### DIFF
--- a/app/domain/etl/ga/internal_search_service.rb
+++ b/app/domain/etl/ga/internal_search_service.rb
@@ -6,75 +6,38 @@ class Etl::GA::InternalSearchService
   def find_in_batches(date:, batch_size: 10_000, &block)
     fetch_data(date:)
       .lazy
-      .map(&:to_h)
-      .flat_map(&method(:extract_rows))
-      .map(&method(:extract_dimensions_and_metrics))
+      .map(&:stringify_keys)
       .map(&method(:append_labels))
-      .map { |hash| set_date(hash, date) }
       .each_slice(batch_size, &block)
   end
 
   def client
-    @client ||= Etl::GA::Client.build
+    @client ||= Etl::GA::Bigquery.build
   end
 
 private
 
-  def set_date(hash, date)
-    hash["date"] = date.strftime("%F")
-    hash
-  end
-
-  def append_labels(values)
-    page_path, searches = *values
-    {
-      "page_path" => page_path,
-      "searches" => searches,
-      "process_name" => "searches",
-    }
-  end
-
-  def extract_dimensions_and_metrics(row)
-    dimensions = row.fetch(:dimensions)
-    metrics = row.fetch(:metrics).flat_map do |metric|
-      metric.fetch(:values).map(&:to_i)
-    end
-
-    dimensions + metrics
-  end
-
-  def extract_rows(report)
-    report.fetch(:rows)
+  def append_labels(hash)
+    hash.merge("process_name" => "searches")
   end
 
   def fetch_data(date:)
-    @fetch_data ||= client.fetch_all(items: :data) do |page_token, service|
-      service
-        .batch_get_reports(
-          Google::Apis::AnalyticsreportingV4::GetReportsRequest.new(
-            report_requests: [build_request(date:).merge(page_token:)],
-          ),
-        )
-        .reports
-        .first
-    end
-  end
+    @fetch_data ||= client
+    @date = date.strftime("%Y-%m-%d")
 
-  def build_request(date:)
-    {
-      date_ranges: [
-        { start_date: date.to_fs("%Y-%m-%d"), end_date: date.to_fs("%Y-%m-%d") },
-      ],
-      dimensions: [
-        { name: "ga:searchStartPage" },
-      ],
-      hide_totals: true,
-      hide_value_ranges: true,
-      metrics: [
-        { expression: "ga:searchUniques" },
-      ],
-      page_size: 10_000,
-      view_id: ENV["GOOGLE_ANALYTICS_GOVUK_VIEW_ID"],
-    }
+    query = <<~SQL
+      WITH CTE1 AS (
+        SELECT *
+        FROM `govuk-content-data.ga4.GA4 dataform`
+        WHERE the_date = @date
+      )
+      SELECT
+        cleaned_page_location AS page_path,
+        total_searches AS searches,
+        the_date AS date,
+      FROM CTE1
+    SQL
+
+    @fetch_data.query(query, params: { date: @date }).all
   end
 end

--- a/spec/domain/etl/ga/internal_search_service_spec.rb
+++ b/spec/domain/etl/ga/internal_search_service_spec.rb
@@ -1,31 +1,22 @@
-require "google/apis/analyticsreporting_v4"
-
 RSpec.describe Etl::GA::InternalSearchService do
-  include GoogleAnalyticsRequests
-
   subject { Etl::GA::InternalSearchService }
 
-  let(:google_client) { instance_double(Google::Apis::AnalyticsreportingV4::AnalyticsReportingService) }
-  before { expect(Etl::GA::Client).to receive(:build).and_return(google_client) }
+  let(:google_client) { instance_double(Google::Cloud::Bigquery::Project) }
+  let(:results) { instance_double(Google::Cloud::Bigquery::Data) }
+
+  before do
+    allow(Etl::GA::Bigquery).to receive(:build).and_return(google_client)
+    allow(google_client).to receive(:query).and_return(results)
+
+    allow(results).to receive(:all).and_return([
+      { "page_path" => "/foo", "searches" => 1, "date" => "2018-02-20" },
+      { "page_path" => "/bar", "searches" => 2, "upviews" => 2, "date" => "2018-02-20" },
+      { "page_path" => "/cool", "searches" => 3, "upviews" => 3, "date" => "2018-02-20" },
+    ])
+  end
 
   describe "#find_in_batches" do
     let(:date) { Date.new(2018, 2, 20) }
-
-    before do
-      allow(google_client).to receive(:fetch_all) do
-        [
-          build_report_data(
-            build_report_row(dimensions: %w[/foo], metrics: %w[1]),
-          ),
-          build_report_data(
-            build_report_row(dimensions: %w[/bar], metrics: %w[2]),
-          ),
-          build_report_data(
-            build_report_row(dimensions: %w[/cool], metrics: %w[3]),
-          ),
-        ]
-      end
-    end
 
     context "when #find_in_batches is called with a block" do
       it "yields successive report data" do
@@ -50,6 +41,18 @@ RSpec.describe Etl::GA::InternalSearchService do
           ),
         ]
 
+        expect { |probe| subject.find_in_batches(date:, batch_size: 2, &probe) }
+          .to yield_successive_args(arg1, arg2)
+      end
+
+      it "includes the process name" do
+        arg1 = [
+          a_hash_including("process_name" => "searches"),
+          a_hash_including("process_name" => "searches"),
+        ]
+        arg2 = [
+          a_hash_including("process_name" => "searches"),
+        ]
         expect { |probe| subject.find_in_batches(date:, batch_size: 2, &probe) }
           .to yield_successive_args(arg1, arg2)
       end


### PR DESCRIPTION
Instead of fetching data from UA we now use the BigQuery API which allows us to query the table for the specific metrics we need from GA4. It already returns the information we need in the correct format and reduces the amount of work required post query.

`ga_response_with_govuk_prefix` has not been used in any of the tests and looks like it has been missed previously. We should expect paths that contain the gov.uk prefix to be transformed into it's base path. If an an event already exists with the same path in the Events::GA table, it should update the entry with the aggregative total for the metrics which is then reflected in the Facts::Metrics table.

This has been tested on [Integration](https://content-data.integration.publishing.service.gov.uk/content). The search data for `1 March 2024 - 26 March 2024` has been repopulated from GA4 and has been reviewed by Performance Analysts. There is a slight variation in the data from GA4 as it is not a direct match for the existing metric in UA, and it is stripping out repeat/non-unique searches.

### Internal searches for past 30 days for gov.uk/sign-in-universal-credit (before, using UA):
![before (past 30 days)](https://github.com/alphagov/content-data-api/assets/19667619/518202ca-7366-4c36-bf40-ddcb939397fd)

### Internal searches for past 30 days for gov.uk/sign-in-universal-credit (after, using GA4):
![after (past 30 days)](https://github.com/alphagov/content-data-api/assets/19667619/fa3896fc-c906-4597-a6dc-917660747c66)

Trello card: https://trello.com/c/hv7dYVuv/3450-migrate-ua-metrics-for-internal-search-to-bigquery-in-content-data-api-5

