### PR TITLE
Upgrade to govuk-dependabot-merger v2

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,30 +1,4 @@
-api_version: 1
-auto_merge:
-  - dependency: gds-api-adapters
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: gds-sso
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_app_config
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_message_queue_consumer
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_schemas
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_test
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: rubocop-govuk
-    allowed_semver_bumps:
-      - patch
-      - minor
+api_version: 2
+defaults:
+  auto_merge: true
+  update_external_dependencies: true


### PR DESCRIPTION
- Upgrades to govuk-dependabot-merger V2
- Enables auto-merge of external dependencies

Trello: https://trello.com/c/iC9shJG4/3479-roll-out-govuk-dependabot-merger-v2-across-select-repositories