### PR TITLE
Remove google-apis-analyticsreporting_v4 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "active_model_serializers"
 gem "activerecord-import"
 gem "awesome_print"
 gem "bootsnap", require: false
-gem "google-apis-analyticsreporting_v4"
 gem "google-cloud-bigquery"
 gem "govuk_message_queue_consumer"
 gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,8 +164,6 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-apis-analyticsreporting_v4 (0.16.0)
-      google-apis-core (>= 0.14.0, < 2.a)
     google-apis-bigquery_v2 (0.66.0)
       google-apis-core (>= 0.14.0, < 2.a)
     google-apis-core (0.14.0)
@@ -803,7 +801,6 @@ DEPENDENCIES
   factory_bot_rails
   gds-api-adapters
   gds-sso
-  google-apis-analyticsreporting_v4
   google-cloud-bigquery
   govuk_app_config
   govuk_message_queue_consumer


### PR DESCRIPTION
This gem is no longer needed now that we have moved to using BigQuery/GA4.

Related PR - https://github.com/alphagov/content-data-api/pull/2076

