### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: npm
+    directory: /doc/api
+    schedule: 
+      internal: none


### PR DESCRIPTION
Dependabot is looking for a package.json file. This PR removes the check.

Alert from: https://github.com/alphagov/content-data-api/security/dependabot/99