### PR TITLE
Remove etl ga rake task

### DIFF
--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -99,10 +99,4 @@ namespace :etl do
       Etl::Main::MainProcessor.process_aggregations(date:)
     end
   end
-
-  desc "Populate GA metrics for a date"
-  task :ga, [:date] => [:environment] do |_t, args|
-    date = args[:date]
-    GA.process(date: date.to_date)
-  end
 end


### PR DESCRIPTION
Description:
- Currently the etl:ga rake task doesn't work as the GA class doesn't exist anymore since it was renamed in https://github.com/alphagov/content-data-api/pull/654 and https://github.com/alphagov/content-data-api/pull/664
- The rake task has been split out into 3 (e.g. Run `Etl::GA:InternalSearchProcessor` etc...)


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

