### PR TITLE
Allow to run etl:rerun_main for a single date

### DIFF
--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -80,12 +80,13 @@ namespace :etl do
     end
   end
 
-  desc "Run ETL Main process across a range of dates"
+  desc "Run ETL Main process across a range of dates or a single date"
   task :rerun_main, %i[from to] => [:environment] do |_t, args|
     from = args[:from].to_date
-    to = args[:to].to_date
+    to = args[:to]&.to_date
     date_range = (from..to)
-    date_range.each do |date|
+
+    date_range.compact.each do |date|
       puts "Running Etl::Main process for #{date}"
       unless Etl::Main::MainProcessor.process(date:)
         abort("Etl::Main::MainProcessor failed")


### PR DESCRIPTION
We are often asked to do this by performance analysts when data didn't appear in BigQuery before the import  run.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

