### PR TITLE
Add missing schemas to prevent `Etl::Edition::Content::Parser::InvalidSchemaError`

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -43,6 +43,7 @@ class Etl::Edition::Content::Parsers::NoContent
       substitute
       topic
       vanish
+      world_index
       world_location
     ]
   end

--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -38,6 +38,7 @@ class Etl::Edition::Content::Parsers::NoContent
       redirect
       role
       role_appointment
+      smart_answer
       special_route
       topic
       vanish

--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -13,6 +13,7 @@ class Etl::Edition::Content::Parsers::NoContent
       facet
       facet_group
       facet_value
+      field_of_operation
       generic
       government
       homepage

--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -18,6 +18,7 @@ class Etl::Edition::Content::Parsers::NoContent
       homepage
       how_government_works
       knowledge_alpha
+      landing_page
       ministers_index
       organisations_homepage
       person

--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -5,9 +5,9 @@ class Etl::Edition::Content::Parsers::NoContent
 
   def schemas
     %w[
-      coronavirus_landing_page
       coming_soon
       completed_transaction
+      coronavirus_landing_page
       embassies_index
       external_content
       facet
@@ -22,23 +22,23 @@ class Etl::Edition::Content::Parsers::NoContent
       ministers_index
       organisations_homepage
       person
+      placeholder
       placeholder_corporate_information_page
       placeholder_ministerial_role
       placeholder_organisation
+      placeholder_person
       placeholder_policy_area
       placeholder_topical_event
       placeholder_world_location
       placeholder_worldwide_organisation
-      placeholder_person
-      placeholder
       policy
       redirect
       role
       role_appointment
       special_route
       topic
-      world_location
       vanish
+      world_location
     ]
   end
 end

--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -40,6 +40,7 @@ class Etl::Edition::Content::Parsers::NoContent
       role_appointment
       smart_answer
       special_route
+      substitute
       topic
       vanish
       world_location

--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -17,6 +17,7 @@ class Etl::Edition::Content::Parsers::NoContent
       generic
       government
       historic_appointments
+      historic_appointment
       homepage
       how_government_works
       knowledge_alpha

--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -16,6 +16,7 @@ class Etl::Edition::Content::Parsers::NoContent
       field_of_operation
       generic
       government
+      historic_appointments
       homepage
       how_government_works
       knowledge_alpha

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       homepage
       how_government_works
       knowledge_alpha
+      landing_page
       ministers_index
       organisations_homepage
       person

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       redirect
       role
       role_appointment
+      smart_answer
       special_route
       topic
       vanish

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       substitute
       topic
       vanish
+      world_index
       world_location
     ]
     no_content_schemas.each do |schema|

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -24,23 +24,23 @@ RSpec.describe Etl::Edition::Content::Parser do
       ministers_index
       organisations_homepage
       person
+      placeholder
       placeholder_corporate_information_page
       placeholder_ministerial_role
       placeholder_organisation
+      placeholder_person
       placeholder_policy_area
       placeholder_topical_event
       placeholder_world_location
       placeholder_worldwide_organisation
-      placeholder_person
-      placeholder
       policy
       redirect
       role
       role_appointment
       special_route
       topic
-      world_location
       vanish
+      world_location
     ]
     no_content_schemas.each do |schema|
       json = build_raw_json(schema_name: schema, body: "<p>Body for #{schema}</p>")

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       facet_group
       facet_value
       generic
+      government
       homepage
       how_government_works
       knowledge_alpha

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       generic
       government
       historic_appointments
+      historic_appointment
       homepage
       how_government_works
       knowledge_alpha

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       role_appointment
       smart_answer
       special_route
+      substitute
       topic
       vanish
       world_location

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       field_of_operation
       generic
       government
+      historic_appointments
       homepage
       how_government_works
       knowledge_alpha

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       facet
       facet_group
       facet_value
+      field_of_operation
       generic
       government
       homepage


### PR DESCRIPTION
Those are all added as "no content" schemas to stop the error. 

The Publishing team may choose to move them to more appropriate parser or create new one to ensure content quality metrics such as word count or reading time are available in Content Data. 

We used to have a test for it, which if I remember correctly run in the CI ensuring the new schema is added to appropriate parser in Content Data API but it was removed by the Publishing team in https://github.com/alphagov/content-data-api/pull/1819/commits/86fc309cb4ae3726fdae1c72fddd030d6af13a75 causing `Etl::Edition::Content::Parser::InvalidSchemaError`.

I'll raise it with Publishing.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

