### PR TITLE
Add rake task to run ETL Main process for a list of dates

### DIFF
--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -100,4 +100,23 @@ namespace :etl do
       Etl::Main::MainProcessor.process_aggregations(date:)
     end
   end
+
+  desc "Run ETL Main process for a list of dates"
+  task rerun_main_list: :environment do |_t, args|
+    dates = args.extras.map(&:to_date)
+
+    dates.compact.each do |date|
+      puts "Running Etl::Main process for #{date}"
+      unless Etl::Main::MainProcessor.process(date:)
+        abort("Etl::Main::MainProcessor failed")
+      end
+      puts "finished running Etl::Main for #{date}"
+    end
+
+    month_ends = dates.map(&:end_of_month).uniq
+    month_ends.each do |date|
+      puts "Running monthly and search aggregations for #{date}"
+      Etl::Main::MainProcessor.process_aggregations(date:)
+    end
+  end
 end


### PR DESCRIPTION
# Description
This new rake task will make it easier to rerun the GA import process for dates that have been missed.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

