### PR TITLE
Add `link_collection` schema to `NoContent` parser

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -22,6 +22,7 @@ class Etl::Edition::Content::Parsers::NoContent
       how_government_works
       knowledge_alpha
       landing_page
+      link_collection
       ministers_index
       organisations_homepage
       person

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Etl::Edition::Content::Parser do
       how_government_works
       knowledge_alpha
       landing_page
+      link_collection
       ministers_index
       organisations_homepage
       person


### PR DESCRIPTION
A schema for `link_collection` was added in https://github.com/alphagov/publishing-api/commit/e3cbefbb6a5adf60be555912f67431f207dad112 but a parser was not defined in this application, resulting in subsequent CI builds failing.

Adding this to the `NoContent` schema as this not a page containing any content, but rather something that is included in other pages to show a list of links.

[Trello card](https://trello.com/c/4BB49LSt)