### PR TITLE
Fix flakey test

### DIFF
--- a/spec/support/schemas_iterator.rb
+++ b/spec/support/schemas_iterator.rb
@@ -7,7 +7,9 @@ module SchemasIterator
   end
 
   def self.payload_for(schema_name, schema)
-    all_payloads[schema_name] ||= GovukSchemas::RandomExample.new(schema:).payload
+    all_payloads[schema_name] ||= GovukSchemas::RandomExample.new(schema:).payload do |payload|
+      payload.merge("base_path" => "/#{schema_name}/#{SecureRandom.uuid}")
+    end
   end
 
   def self.all_payloads


### PR DESCRIPTION
The `./spec/integration/streams/all_schemas_spec.rb` tests are flakey as the payload sent to the message queue does not always contain a base path.

This means the test passes on occasion when it shouldn't,  because the application has been designed to silently ignore invalid payloads.

Explicitly adding a base path for these tests, to remove the flakiness.

Depends on https://github.com/alphagov/content-data-api/pull/2243 (to fix a failing test which passes ~25% of the time before this change).

[Trello card](https://trello.com/c/4BB49LSt)
