### PR TITLE
Add a test for presence of parser for every schema

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -7,6 +7,9 @@ class Etl::Edition::Content::Parsers::NoContent
     %w[
       coming_soon
       completed_transaction
+      content_block_email_address
+      content_block_pension
+      content_block_postal_address
       coronavirus_landing_page
       embassies_index
       external_content
@@ -16,8 +19,8 @@ class Etl::Edition::Content::Parsers::NoContent
       field_of_operation
       generic
       government
-      historic_appointments
       historic_appointment
+      historic_appointments
       homepage
       how_government_works
       knowledge_alpha

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Etl::Edition::Content::Parser do
     no_content_schemas = %w[
       coming_soon
       completed_transaction
+      content_block_email_address
+      content_block_pension
+      content_block_postal_address
       coronavirus_landing_page
       embassies_index
       external_content
@@ -18,8 +21,8 @@ RSpec.describe Etl::Edition::Content::Parser do
       field_of_operation
       generic
       government
-      historic_appointments
       historic_appointment
+      historic_appointments
       homepage
       how_government_works
       knowledge_alpha

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe "Process all schemas" do
   let(:subject) { Streams::Consumer.new }
 
   SchemasIterator.each_schema do |schema_name, schema|
+    it "has a parser for #{schema_name}" do
+      expect(Etl::Edition::Content::Parser.new.send(:for_schema, schema_name)).not_to be_nil
+    end
+
     %w[major minor links republish unpublish].each do |update_type|
       it "handles event for: `#{schema_name}` with no errors for a `#{update_type}` update" do
         expect(GovukError).not_to receive(:notify)


### PR DESCRIPTION
It is possible to add a schema to `publishing-api` which has an optional base path.

If a docment does not have a base path, this application silently ignores the message and continues processing further jobs.

This leads to the other test here being flakey, since sometimes the message will be silently dropped (because the random content generator has created content without a base path) even though the test should be failing as there is no relevant parser defined.

Therefore adding an additional test that ensures a parser is explicitly defined for each schema type.

[Trello card](https://trello.com/c/4BB49LSt)