### PR TITLE
Fix InFailedSqlTransaction errors by aborting failed transactions

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -43,6 +43,7 @@ class Dimensions::Edition < ApplicationRecord
     update!(live: true) unless unpublished?
   rescue ActiveRecord::RecordNotUnique
     logger.info("Duplicate live edition detected for base_path: #{base_path}, skipping promotion.")
+    raise ActiveRecord::Rollback
   end
 
   def unpublished?


### PR DESCRIPTION
Rescuing `ActiveRecord::RecordNotUnique` without aborting the transaction left the connection in a failed state, causing subsequent SQL commands to trigger `PG::InFailedSqlTransaction` errors. This adds a `raise ActiveRecord::Rollback` to immediately roll back the transaction, preventing further queries on a tainted connection.

https://github.com/alphagov/content-data-api/issues/2251