### PR TITLE
Ignore content block schemas when testing for parsers

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -7,6 +7,7 @@ class Etl::Edition::Content::Parsers::NoContent
     %w[
       coming_soon
       completed_transaction
+      content_block_contact
       content_block_email_address
       content_block_pension
       content_block_postal_address

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Etl::Edition::Content::Parser do
     no_content_schemas = %w[
       coming_soon
       completed_transaction
+      content_block_contact
       content_block_email_address
       content_block_pension
       content_block_postal_address


### PR DESCRIPTION
# Description
https://trello.com/c/Fa5E0qo6/1031-tech-task-create-basic-contact-content-block-schema

Content Blocks are not rendered on frontend so they do not need a parser, following the pattern set previously [1]

[1] https://github.com/alphagov/content-data-api/commit/e02a85381dac95a7a08964e81587a1b49e384554

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

