### PR TITLE
Configure CI workflow to handle concurrent releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       - ".git**"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:  
   security-analysis:
     name: Security Analysis


### PR DESCRIPTION
**As a** platform engineer
**I want** our deployment process for our app repos to handle concurrent releases
**so that** we avoid issues with incorrect ordering of releases

https://github.com/alphagov/govuk-infrastructure/issues/2123