### PR TITLE
CM-71: delete `content_block_email_address` and `content_block_postal_address`

### DIFF
--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -8,7 +8,6 @@ class Etl::Edition::Content::Parsers::NoContent
       coming_soon
       completed_transaction
       content_block_contact
-      content_block_email_address
       content_block_pension
       content_block_postal_address
       coronavirus_landing_page

--- a/app/domain/etl/edition/content/parsers/no_content.rb
+++ b/app/domain/etl/edition/content/parsers/no_content.rb
@@ -9,7 +9,6 @@ class Etl::Edition::Content::Parsers::NoContent
       completed_transaction
       content_block_contact
       content_block_pension
-      content_block_postal_address
       coronavirus_landing_page
       embassies_index
       external_content

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Etl::Edition::Content::Parser do
       coming_soon
       completed_transaction
       content_block_contact
-      content_block_email_address
       content_block_pension
       content_block_postal_address
       coronavirus_landing_page

--- a/spec/domain/etl/edition/content/no_content_spec.rb
+++ b/spec/domain/etl/edition/content/no_content_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Etl::Edition::Content::Parser do
       completed_transaction
       content_block_contact
       content_block_pension
-      content_block_postal_address
       coronavirus_landing_page
       embassies_index
       external_content

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Process all schemas" do
   SchemasIterator.each_schema do |schema_name, schema|
     it "has a parser for #{schema_name}" do
       # Included as a temporary measure to ignore content block schemas that are in process of deletion
-      schemas_to_be_deleted = %w[content_block_email_address]
+      schemas_to_be_deleted = %w[content_block_email_address content_block_postal_address]
 
       unless schemas_to_be_deleted.include?(schema_name)
         expect(Etl::Edition::Content::Parser.new.send(:for_schema, schema_name)).not_to be_nil

--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe "Process all schemas" do
 
   SchemasIterator.each_schema do |schema_name, schema|
     it "has a parser for #{schema_name}" do
-      expect(Etl::Edition::Content::Parser.new.send(:for_schema, schema_name)).not_to be_nil
+      # Included as a temporary measure to ignore content block schemas that are in process of deletion
+      schemas_to_be_deleted = %w[content_block_email_address]
+
+      unless schemas_to_be_deleted.include?(schema_name)
+        expect(Etl::Edition::Content::Parser.new.send(:for_schema, schema_name)).not_to be_nil
+      end
     end
 
     %w[major minor links republish unpublish].each do |update_type|


### PR DESCRIPTION
# Description

Following work done on Whitehall here https://github.com/alphagov/whitehall/pull/10231

We began the project with `email_address` and `postal_address` as our first blocks - it looks like these types will never exist for our users so we should remove them and base things on types we are certain of.

As per this convo https://gds.slack.com/archives/CAB4Q3QBW/p1747988704839469?thread_ts=1747924528.758559&cid=CAB4Q3QBW I've had to do a bit of a hacky check in the tests while the schemas have yet to be deleted in publishing API 
Once this PR is merged, I will be able to make these changes in Publishing API https://github.com/alphagov/publishing-api/pull/3356 and then come back and tidy up test!

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

