### PR TITLE
CM-71: Tidy up test for deleted content block schemas

### DIFF
--- a/spec/integration/streams/all_schemas_spec.rb
+++ b/spec/integration/streams/all_schemas_spec.rb
@@ -5,12 +5,7 @@ RSpec.describe "Process all schemas" do
 
   SchemasIterator.each_schema do |schema_name, schema|
     it "has a parser for #{schema_name}" do
-      # Included as a temporary measure to ignore content block schemas that are in process of deletion
-      schemas_to_be_deleted = %w[content_block_email_address content_block_postal_address]
-
-      unless schemas_to_be_deleted.include?(schema_name)
-        expect(Etl::Edition::Content::Parser.new.send(:for_schema, schema_name)).not_to be_nil
-      end
+      expect(Etl::Edition::Content::Parser.new.send(:for_schema, schema_name)).not_to be_nil
     end
 
     %w[major minor links republish unpublish].each do |update_type|


### PR DESCRIPTION
# Description
Blocked by: https://github.com/alphagov/publishing-api/pull/3356

Once the schemas have been removed on Publishing API we don't need to have this provisional check.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

