### PR TITLE
[PP-7262] Ignore `substitute` document type

### DIFF
--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -2,7 +2,14 @@ class DocumentType
   include ActiveModel::Model
   include ActiveModel::Serialization
 
-  IGNORED_TYPES = %w[redirect gone vanish unpublishing need].freeze
+  IGNORED_TYPES = %w[
+    gone
+    need
+    redirect
+    substitute
+    unpublishing
+    vanish
+  ].freeze
 
   attr_accessor :id, :name
 end

--- a/spec/requests/document_types_spec.rb
+++ b/spec/requests/document_types_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "/document_types" do
     create :edition, document_type: "vanish"
     create :edition, document_type: "unpublishing"
     create :edition, document_type: "need"
+    create :edition, document_type: "substitute"
 
     get "/api/v1/document_types"
     json = JSON.parse(response.body).deep_symbolize_keys


### PR DESCRIPTION
The document type of `substitute` was added in https://github.com/alphagov/publishing-api/pull/2664 but wasn't added to this application as a type of unpublishing that should be ignored.

Therefore adding it here, so the type is not surfaced in the user interface.