### PR TITLE
[PP-7588] Bump govuk_schemas from 6.3.0 to 6.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
     govuk_message_queue_consumer (6.1.0)
       bunny (~> 2.17)
       ostruct
-    govuk_schemas (6.3.0)
+    govuk_schemas (6.3.1)
       json-schema (>= 2.8, < 6.3)
     govuk_sidekiq (11.1.2)
       gds-api-adapters (>= 19.1.0)


### PR DESCRIPTION
This is needed to support an upcoming change in the schema definition for base paths (https://github.com/alphagov/publishing-api/pull/4018)