### PR TITLE
Spike adding Navigation schema [WHIT-3342]

### DIFF
--- a/app/domain/etl/edition/content/parser.rb
+++ b/app/domain/etl/edition/content/parser.rb
@@ -39,6 +39,7 @@ private
       ::Etl::Edition::Content::Parsers::Licence,
       ::Etl::Edition::Content::Parsers::LocalTransaction,
       ::Etl::Edition::Content::Parsers::Mainstream,
+      ::Etl::Edition::Content::Parsers::Navigation,
       ::Etl::Edition::Content::Parsers::Need,
       ::Etl::Edition::Content::Parsers::Parts,
       ::Etl::Edition::Content::Parsers::Place,

--- a/app/domain/etl/edition/content/parsers/navigation.rb
+++ b/app/domain/etl/edition/content/parsers/navigation.rb
@@ -1,0 +1,11 @@
+class Etl::Edition::Content::Parsers::Navigation
+  def parse(json)
+    html = []
+    html << json.dig("details", "menu_items").map { |item| item["content_id"] }.join(" ")
+    html.join(" ")
+  end
+
+  def schemas
+    %w[navigation]
+  end
+end

--- a/spec/domain/etl/edition/content/navigation_spec.rb
+++ b/spec/domain/etl/edition/content/navigation_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Etl::Edition::Content::Parser do
+  subject { described_class }
+
+  it "returns content if schema name is 'navigation'" do
+    json = {
+      schema_name: "navigation",
+      details: {
+        menu_items: [
+          { content_id: "abc123" },
+          { content_id: "def456" },
+        ],
+      },
+    }
+    expected = [
+      "abc123 def456",
+    ].join(" ")
+    expect(subject.extract_content(json.deep_stringify_keys)).to eq(expected)
+  end
+end


### PR DESCRIPTION
# Description
Adds parser for Navigation schema as we're adding a new schema and Publishing API CI fails if Content Data API has no parser for it.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
*  ~~Added/updated feature tests~~.
* ~~Added/updated relevant documentation~~.
* [x] Added to Trello card.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3342

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

