### PR TITLE
CR-53 MHCLG missing from list of organisation seen in admin UI

### DIFF
--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -47,7 +47,7 @@ class Dimensions::Edition < ApplicationRecord
   end
 
   def unpublished?
-    %w[gone vanish redirect].include?(document_type)
+    %w[gone vanish redirect substitute].include?(document_type)
   end
 
   def change_from?(attributes)

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -40,7 +40,11 @@ class Dimensions::Edition < ApplicationRecord
 
   def promote!(old_edition)
     old_edition.update!(live: false) if old_edition
-    update!(live: true) unless unpublished?
+
+    return if unpublished?
+
+    demote_any_live_editions_on_same_base_path
+    update!(live: true)
   rescue ActiveRecord::RecordNotUnique
     logger.info("Duplicate live edition detected for base_path: #{base_path}, skipping promotion.")
     raise ActiveRecord::Rollback
@@ -83,5 +87,14 @@ class Dimensions::Edition < ApplicationRecord
     return child_count unless child_count.zero?
 
     parent.try(:related_content_count) || 0
+  end
+
+private
+
+  def demote_any_live_editions_on_same_base_path
+    self.class
+        .where(base_path: base_path, live: true)
+        .where.not(id: id)
+        .update_all(live: false)
   end
 end

--- a/app/models/dimensions/edition.rb
+++ b/app/models/dimensions/edition.rb
@@ -45,9 +45,6 @@ class Dimensions::Edition < ApplicationRecord
 
     demote_any_live_editions_on_same_base_path
     update!(live: true)
-  rescue ActiveRecord::RecordNotUnique
-    logger.info("Duplicate live edition detected for base_path: #{base_path}, skipping promotion.")
-    raise ActiveRecord::Rollback
   end
 
   def unpublished?

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -1,0 +1,40 @@
+namespace :organisations do
+  desc "Identify organisations missing from CDA and provide replay instructions"
+  task check_missing: :environment do
+    known_missing = %w[
+      1390d07f-12b3-4f55-9dd5-fec5fd9e3649
+      63953ed9-98ac-4d08-a1b9-8ea38dbd0832
+      99a5828c-79dd-4533-ab18-18069be289cf
+    ]
+
+    puts "Checking for missing organisations..."
+    puts
+
+    still_missing = known_missing.reject do |content_id|
+      Dimensions::Edition.exists?(content_id:, live: true)
+    end
+
+    no_op_message = "All organisations are present and live. Nothing to do."
+    next puts no_op_message if still_missing.empty?
+
+    puts "#{still_missing.size} organisation(s) still missing from CDA:"
+    puts
+    still_missing.each do |content_id|
+      edition = Dimensions::Edition.find_by(content_id:)
+      status = if edition
+                 "exists but live=#{edition.live}"
+               else
+                 "no record"
+               end
+      puts "  #{content_id} (#{status})"
+    end
+    puts
+    puts "To fix, run the following on Publishing API console:"
+    puts
+    puts "  %w[#{still_missing.join(' ')}].each do |content_id|"
+    puts "    Commands::V2::RepresentDownstream.new.call(content_id)"
+    puts "  end"
+    puts
+    puts "Then re-run this task to verify."
+  end
+end

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -170,6 +170,18 @@ RSpec.describe Dimensions::Edition, type: :model do
         expect(new_edition.reload.live).to be true
       end
     end
+
+    context "when RecordNotUnique is raised unexpectedly" do
+      let(:edition) { create :edition, live: false }
+
+      it "lets the exception propagate for job-level retry" do
+        allow(edition).to receive(:update!)
+          .and_raise(ActiveRecord::RecordNotUnique)
+
+        expect { edition.promote!(nil) }
+          .to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
   end
 
   describe "#change_from?" do

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -140,6 +140,36 @@ RSpec.describe Dimensions::Edition, type: :model do
         expect(old_edition.live).to be false
       end
     end
+
+    context "when a different content_id occupies the same base_path" do
+      let(:base_path) { "/government/organisations/example-org" }
+
+      let!(:blocking_edition) do
+        create :edition,
+               base_path: base_path,
+               content_id: SecureRandom.uuid,
+               live: true
+      end
+
+      let(:new_edition) do
+        create :edition,
+               base_path: base_path,
+               content_id: SecureRandom.uuid,
+               live: false
+      end
+
+      it "demotes the blocking edition at the same base_path" do
+        new_edition.promote!(nil)
+
+        expect(blocking_edition.reload.live).to be false
+      end
+
+      it "promotes the new edition to live" do
+        new_edition.promote!(nil)
+
+        expect(new_edition.reload.live).to be true
+      end
+    end
   end
 
   describe "#change_from?" do

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -124,6 +124,22 @@ RSpec.describe Dimensions::Edition, type: :model do
         expect(old_edition.live).to be false
       end
     end
+
+    context "for substitute edition" do
+      let(:edition) { build :edition, live: false, document_type: "substitute" }
+      let(:warehouse_item_id) { "warehouse-item-id" }
+      let(:old_edition) { build :edition, live: true, warehouse_item_id: }
+
+      it "does not set the live attribute to true" do
+        edition.promote!(old_edition)
+        expect(edition.live).to be false
+      end
+
+      it "sets the live attribute to false for the old version" do
+        edition.promote!(old_edition)
+        expect(old_edition.live).to be false
+      end
+    end
   end
 
   describe "#change_from?" do

--- a/spec/models/dimensions/edition_spec.rb
+++ b/spec/models/dimensions/edition_spec.rb
@@ -100,12 +100,12 @@ RSpec.describe Dimensions::Edition, type: :model do
 
       it "sets the live attribute to true" do
         edition.promote!(old_edition)
-        expect(edition.live).to be true
+        expect(edition.reload.live).to be true
       end
 
       it "sets the live attribute to false for the old version" do
         edition.promote!(old_edition)
-        expect(old_edition.live).to be false
+        expect(old_edition.reload.live).to be false
       end
     end
 
@@ -121,7 +121,7 @@ RSpec.describe Dimensions::Edition, type: :model do
 
       it "sets the live attribute to false for the old version" do
         edition.promote!(old_edition)
-        expect(old_edition.live).to be false
+        expect(old_edition.reload.live).to be false
       end
     end
 
@@ -137,7 +137,7 @@ RSpec.describe Dimensions::Edition, type: :model do
 
       it "sets the live attribute to false for the old version" do
         edition.promote!(old_edition)
-        expect(old_edition.live).to be false
+        expect(old_edition.reload.live).to be false
       end
     end
 

--- a/spec/tasks/organisations_spec.rb
+++ b/spec/tasks/organisations_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe "rake organisations:*", type: :task do
+  before do
+    allow($stdout).to receive(:puts)
+  end
+
+  describe "check_missing" do
+    let(:task) { Rake::Task["organisations:check_missing"] }
+
+    before { task.reenable }
+
+    context "when organisations are missing" do
+      it "reports content_ids with no live edition" do
+        create :edition,
+               content_id: "1390d07f-12b3-4f55-9dd5-fec5fd9e3649",
+               live: false
+
+        task.invoke
+
+        expect($stdout).to have_received(:puts)
+          .with(/1390d07f.*exists but live=false/)
+      end
+
+      it "reports content_ids with no record at all" do
+        task.invoke
+
+        expect($stdout).to have_received(:puts)
+          .with(/1390d07f.*no record/)
+      end
+    end
+
+    context "when all organisations are present" do
+      before do
+        %w[
+          1390d07f-12b3-4f55-9dd5-fec5fd9e3649
+          63953ed9-98ac-4d08-a1b9-8ea38dbd0832
+          99a5828c-79dd-4533-ab18-18069be289cf
+        ].each do |content_id|
+          create :edition, content_id:, live: true
+        end
+      end
+
+      it "reports nothing to do" do
+        task.invoke
+
+        expect($stdout).to have_received(:puts)
+          .with(/All organisations are present/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this PR we fix two bugs which have caused organisations including MHCLG (Ministry of Housing, Communities & Local Government) to be missing from the Content Data Admin interface. 

See [CR-53](https://gov-uk.atlassian.net/browse/CR-53) which was created from [Zendesk ticket 6611295](https://govuk.zendesk.com/agent/tickets/6611295 "https://govuk.zendesk.com/agent/tickets/6611295"). That ticket describes a long standing issue:

> Hi
> 
> The Ministry of Housing, Communities and Local Government (MHCLG) is missing from the Organisation dropdown list. Can you add this in?
> 
> It currently only lists the old organisation: MHCLG (2018 to 2021).
> 
> We have raised a couple of other times, but both have been marked solved and we haven't seen added as a new org.
> 
> PREVIOUS TICKETS:
> 
> [MHCLG missing from Content Data - Govt Agency General Issue – GOV.UK](https://govuk.zendesk.com/hc/en-us/requests/5953490 "https://govuk.zendesk.com/hc/en-us/requests/5953490")
> 
> [https://govuk.zendesk.com/hc/requests/5953321](https://govuk.zendesk.com/hc/requests/5953321 "https://govuk.zendesk.com/hc/requests/5953321")
> 
> Can you review and add us please?

[Issue 2169 ](https://github.com/alphagov/content-data-api/issues/2169) also describes the MHCLG problem and notes that it
> is because Content Data considers it's document type as "substitute" 

## Summary

At present there are 2 editions of the MHCLG competing to be "live":


1. the **old** with `content_id` of `33479fe6-d274-4ab6-bf37-053ebd7fd162`
2. the **new** with `content_id` of `1390d07f-12b3-4f55-9dd5-fec5fd9e3649`

Both wish to use the same `base_path` of `/government/organisations/ministry-of-housing-communities-and-local-government`

The new record can't get successfully "promoted" to the live state as it's unable to demote the incumbent.

## Bugs

On investigation this turns out to be a long standing problem resulting from two problems fixed here:

### 1. "substitute" was not recognised as unpublished

An "unpublished" event of type "substitute" should never be made live. In Content Data API the definition of "unpublished" did not include "substitute". This led to the "old" edition of MHCLG being set as "live".

### 2. demotion did not include editions with matching base_path

When attempting to "promote" a new edition, we were "demoting" any live edition with the same `content_id`. However, we were not also demoting editions with a different `content_id` but the same `base_path`. We have unique indexes on both:

- `content_id` + `live == true` and 
- `base_path` + `live == true`

Since July 2024 we've had 3 editions for the "old" MHCLG record (with `content_id`  of `33479fe6-d274-4ab6-bf37-053ebd7fd162`):

| #   | ID       | created_at (BST)    | document_type | live     | event_id |
| --- | -------- | ------------------- | ------------- | -------- | -------- |
| 1   | 19553926 | 2024-07-09 14:04:03 | organisation  | false    | 4496248  |
| 2   | 19554005 | 2024-07-09 14:09:51 | gone          | false    | 4496324  |
| 3   | 19578717 | 2024-07-11 09:53:50 | substitute    | **true** | 4520698  |

Every attempt since to promote the `content_id` / `warehouse_id` for the new MHCLG record (`content_id`: `1390d07f-12b3-4f55-9dd5-fec5fd9e3649`) has failed due to this db constraint. 

We can see numerous recent events in Publishing API which will have emitted messages of this type:

```rb
Event.where(
  content_id: "1390d07f-12b3-4f55-9dd5-fec5fd9e3649", 
  action: ["Publish", "PatchLinkSet"]
  )
  .order(created_at: :desc)
  .limit(25)
  .pluck(:action, :created_at)
=>
[["Publish", 2026-07-16 12:57:17.214978000 UTC +00:00],
 ["PatchLinkSet", 2026-07-16 12:57:17.151597000 UTC +00:00],
 ["PatchLinkSet", 2026-07-16 12:57:17.000083000 UTC +00:00],
 ["PatchLinkSet", 2026-07-16 12:57:16.978320000 UTC +00:00],
 ["Publish", 2026-07-16 12:50:04.095716000 UTC +00:00],
 ...
 ["PatchLinkSet", 2026-07-15 15:35:29.353119000 UTC +00:00],
 ["PatchLinkSet", 2026-07-15 15:35:29.140004000 UTC +00:00],
 ["Publish", 2026-07-15 15:35:06.420799000 UTC +00:00],
 ["PatchLinkSet", 2026-07-15 15:35:06.270862000 UTC +00:00],
 ["Publish", 2026-07-15 15:33:06.735484000 UTC +00:00],
 ["PatchLinkSet", 2026-07-15 15:33:06.518405000 UTC +00:00],
 ["Publish", 2026-07-13 13:02:27.263596000 UTC +00:00]]
```

## Remediation

Once these fixes are deployed we'll be able to manually trigger messages from Publishing API to get the 2 missing organisations correctly promoted in Content Data API:

```rb
%w[
  1390d07f-12b3-4f55-9dd5-fec5fd9e3649
  63953ed9-98ac-4d08-a1b9-8ea38dbd0832
].each do |content_id|
  Commands::V2::RepresentDownstream.new.call(content_id)
end
```
## Broader implications

These bugs will have affected all document types, not just organisations. It would be a big job to perform reconciliations for every document types between Content Data API and Publishing API, but as documents are republished, promotions which were previously blocked will take place. 

Republication, including periodic bulk republication for maintenance, is common, so this gradual approach seems adequate. As Content Data API is an analytics data warehouse, rather than a critical operational system, this form of event-driven self-healing over time seems like an appropriate overall remediation strategy.

[CR-53]: https://gov-uk.atlassian.net/browse/CR-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ